### PR TITLE
feat: Add LLM usage guide and component listings

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -35,6 +35,7 @@ jobs:
           mkdir -p dist
           cp demo.html dist/index.html
           cp react-icons/packages/_react-icons_all/demo-bundle.js dist/
+          cp llm.txt dist/
           cp -r svg dist/
 
       - name: Deploy to GitHub Pages

--- a/DemoApp.tsx
+++ b/DemoApp.tsx
@@ -889,6 +889,63 @@ function IconsUiDetail({ name, onBack, onOpen }: { name: string; onBack: () => v
   );
 }
 
+function LlmUsage() {
+  return (
+    <div className="card">
+      <h2 style={{ marginTop: 0 }}>LLM Usage</h2>
+      <p style={{ color: "#555", lineHeight: 1.6 }}>
+        Use <a href="llm.txt" target="_blank" rel="noopener noreferrer">llm.txt</a>{" "}
+        for copy-ready examples and complete generated listings of{" "}
+        <code>@flanksource/icons</code> names and <code>@flanksource/icons-ui</code>{" "}
+        components.
+      </p>
+
+      <div className="examples-grid" style={{ marginTop: 16 }}>
+        <div className="example-card">
+          <h3>Icon names</h3>
+          <div style={{ fontSize: 12, color: "#666", lineHeight: 1.5, marginBottom: 8 }}>
+            Prefer exact names from the generated list. The demo currently exposes{" "}
+            {allIconNames.length} bundled SVG icons.
+          </div>
+          <div className="code-snippet" style={{ fontSize: 12 }}>
+            {'import { Icon } from "@flanksource/icons/icon";\n\n<Icon name="aws-ec2" className="h-6 max-w-6" />\n<Icon name="k8s-pod" color="blue" />'}
+          </div>
+        </div>
+
+        <div className="example-card">
+          <h3>Runtime resources</h3>
+          <div style={{ fontSize: 12, color: "#666", lineHeight: 1.5, marginBottom: 8 }}>
+            Use ResourceIcon when the name comes from provider, resource type, service, or config data.
+          </div>
+          <div className="code-snippet" style={{ fontSize: 12 }}>
+            {'import { ResourceIcon } from "@flanksource/icons/icon";\n\n<ResourceIcon primary="Kubernetes::Pod" secondary="KubernetesResource" />\n<ResourceIcon primary="datadog" />'}
+          </div>
+        </div>
+
+        <div className="example-card">
+          <h3>File types</h3>
+          <div style={{ fontSize: 12, color: "#666", lineHeight: 1.5, marginBottom: 8 }}>
+            Use FileTypeIcon for filenames and extensions instead of guessing icon names.
+          </div>
+          <div className="code-snippet" style={{ fontSize: 12 }}>
+            {'import { FileTypeIcon } from "@flanksource/icons/icon";\n\n<FileTypeIcon name="config.yaml" />\n<FileTypeIcon name="main.go" />'}
+          </div>
+        </div>
+
+        <div className="example-card">
+          <h3>UI components</h3>
+          <div style={{ fontSize: 12, color: "#666", lineHeight: 1.5, marginBottom: 8 }}>
+            Use the {iconsUiEntries.length} generated React components for interface controls and states.
+          </div>
+          <div className="code-snippet" style={{ fontSize: 12 }}>
+            {'import { UiCheck, UiSearch, UiUpload } from "@flanksource/icons-ui";\n\n<UiSearch size={16} className="text-slate-700" />\n<UiCheck size={16} className="text-emerald-600" />\n<UiUpload size={16} />'}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function App() {
   const [tab, setTab] = useState("Icon Playground");
   const [pgState, setPgState] = useState({ name: "aws-ec2", secondary: "", color: "", square: "auto" as "auto" | "true" | "false" });
@@ -912,7 +969,8 @@ function App() {
         ~{allIconNames.length} curated icons in <code>@flanksource/icons</code>{" "}
         + {iconsUiEntries.length} curated React components in{" "}
         <code>@flanksource/icons-ui</code> &mdash;{" "}
-        <a href="https://github.com/flanksource/flanksource-icons">GitHub</a>
+        <a href="https://github.com/flanksource/flanksource-icons">GitHub</a>{" "}
+        &middot; <a href="llm.txt">llm.txt</a>
       </p>
       <Tabs
         tabs={[
@@ -922,6 +980,7 @@ function App() {
           "File Types",
           "Browse All",
           `Icons UI (${iconsUiEntries.length})`,
+          "LLM Usage",
         ]}
         active={tab}
         onSelect={setTab}
@@ -936,6 +995,7 @@ function App() {
       {tab === "Examples" && <Examples onSelect={switchToPlayground} />}
       {tab === "File Types" && <FileTypeExamples />}
       {tab === "Browse All" && <Browse onSelect={(name) => switchToPlayground(name)} />}
+      {tab === "LLM Usage" && <LlmUsage />}
       {tab.startsWith("Icons UI") && (
         iconsUiDetail
           ? <IconsUiDetail name={iconsUiDetail} onBack={() => setIconsUiDetail(null)} onOpen={(n) => setIconsUiDetail(n)} />

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ dist: demo
 	mkdir -p dist
 	cp demo.html dist/index.html
 	cp react-icons/packages/_react-icons_all/demo-bundle.js dist/
+	cp llm.txt dist/
 	cp -r svg dist/
 
 # Build the demo and open it in the default browser.

--- a/demo.html
+++ b/demo.html
@@ -22,6 +22,7 @@
         /* Tabs */
         .tabs {
             display: flex;
+            flex-wrap: wrap;
             gap: 0;
             border-bottom: 2px solid #ddd;
             margin-bottom: 24px;

--- a/llm.txt
+++ b/llm.txt
@@ -1,0 +1,285 @@
+# Flanksource Icons LLM Usage
+
+This file is generated from the Flanksource Icons repository for LLMs and coding agents.
+Use exact icon names from the listings below when generating code.
+
+Demo: https://flanksource.github.io/flanksource-icons/
+Repository: https://github.com/flanksource/flanksource-icons
+NPM packages: @flanksource/icons, @flanksource/icons-ui
+
+## Install
+
+```sh
+pnpm add @flanksource/icons @flanksource/icons-ui
+```
+
+Both packages require React as a peer dependency.
+
+## Choose The Right Component
+
+- Use @flanksource/icons/icon Icon when you know a curated SVG icon name.
+- Use ResourceIcon when the icon name comes from runtime data such as resource type, cloud provider, service, or config class.
+- Use FileTypeIcon when rendering file names or file extensions.
+- Use @flanksource/icons-ui components for UI actions, status, navigation, and product interface symbols.
+
+## Usage Examples
+
+```tsx
+import { Icon, ResourceIcon, FileTypeIcon } from "@flanksource/icons/icon";
+
+export function Examples() {
+  return (
+    <>
+      <Icon name="aws-ec2" className="h-6 max-w-6" />
+      <Icon name="k8s-pod" color="blue" />
+      <ResourceIcon primary="Kubernetes::Pod" secondary="KubernetesResource" className="h-6 max-w-6" />
+      <ResourceIcon primary="datadog" className="h-6 max-w-6" />
+      <FileTypeIcon name="config.yaml" className="h-6 max-w-6" />
+    </>
+  );
+}
+```
+
+```tsx
+import { UiCheck, UiUpload, UiSearch, UiWarningCircleFilled } from "@flanksource/icons-ui";
+
+export function Toolbar() {
+  return (
+    <>
+      <UiSearch size={16} className="text-slate-700" />
+      <UiUpload size={16} />
+      <UiCheck size={16} className="text-emerald-600" title="complete" />
+      <UiWarningCircleFilled size={16} className="text-amber-600" />
+    </>
+  );
+}
+```
+
+## Resolution Notes
+
+Icon accepts exact names from the @flanksource/icons listing and also supports the aliases and prefix matching built into the package.
+ResourceIcon first checks bundled icons, then falls back to allowed Iconify logo/devicon matches when enabled.
+FileTypeIcon maps common filenames and extensions to bundled icons.
+Most @flanksource/icons-ui outline icons use currentColor, so CSS color utilities such as className="text-blue-500" work.
+
+## @flanksource/icons Names (1125)
+
+access-denied, activemq, activity, activity-feed, activity-feed-o, add, add-alarm, add-alarm-clock
+add-alert, add-certificate, add-clock, add-cloud, add-cost, add-database, add-disk, add-email
+add-firewall, add-folder, add-group, add-heart, add-inbox, add-key, add-list, add-network-card
+add-node, add-page, add-properties, add-receipt, add-shield, add-snapshot, add-tag, add-ticket
+add-user, advanced-search, ai, airflow, akamai, alarm, alarm-bell, alarm-clock
+alarm-clock-check, alarm-clock-off, alarm2, alarm3, alert, angular, ansible, anthropic
+apache, apache-pulsar, apache-spark, approval, approve, archive, argo, artifact-registry
+ask-question, auth0, aws, aws-ack, aws-acm, aws-alb, aws-ami, aws-api-gateway
+aws-audit-manager, aws-auto-scaling, aws-beanstalk, aws-cloud-directory, aws-cloudformation, aws-cloudfront, aws-cloudtrail, aws-cloudwatch
+aws-cloudwatch-alarm, aws-config, aws-detective, aws-directory-service, aws-dnszone, aws-documentdb, aws-dynamodb, aws-ebs-volume
+aws-ec2, aws-ec2-a1, aws-ec2-ami, aws-ec2-auto-scaling, aws-ec2-beanstalk, aws-ec2-c5, aws-ec2-c6a, aws-ec2-c6g
+aws-ec2-c6i, aws-ec2-c7g, aws-ec2-cloudwatch, aws-ec2-d2, aws-ec2-d3, aws-ec2-db, aws-ec2-dl1, aws-ec2-eip
+aws-ec2-f1, aws-ec2-g4ad, aws-ec2-g4dn, aws-ec2-g5, aws-ec2-h1, aws-ec2-habana-gaudi, aws-ec2-hmi, aws-ec2-hpc6a
+aws-ec2-i3, aws-ec2-i3en, aws-ec2-im4gn, aws-ec2-inf1, aws-ec2-instance, aws-ec2-instances, aws-ec2-is4gen, aws-ec2-m1-mac
+aws-ec2-m4, aws-ec2-m5, aws-ec2-m6a, aws-ec2-m6g, aws-ec2-m6i, aws-ec2-mac, aws-ec2-p2, aws-ec2-p3
+aws-ec2-p4, aws-ec2-r4, aws-ec2-r5, aws-ec2-r6g, aws-ec2-r6i, aws-ec2-rdn, aws-ec2-route-table, aws-ec2-spot
+aws-ec2-t3, aws-ec2-t3a, aws-ec2-t4g, aws-ec2-trainium, aws-ec2-trn1, aws-ec2-vpc, aws-ec2-vt1, aws-ec2-x1
+aws-ec2-x2gd, aws-ec2-x2iedn, aws-ec2-x2iezn, aws-ec2-z1d, aws-ecr, aws-ecr-repository, aws-ecs, aws-ecs-service
+aws-ecs-task, aws-efs, aws-eks-cluster, aws-elastic-ip, aws-elasticache, aws-elb, aws-eni, aws-fargate
+aws-firewall, aws-firewall-manager, aws-guard-duty, aws-iam, aws-iam-role, aws-iam-sts, aws-iam-user, aws-inspector
+aws-kms, aws-lambda, aws-macie, aws-rds, aws-route53-hostedzone, aws-s3, aws-secrets-manager, aws-security-group
+aws-ses, aws-shield, aws-sns, aws-sqs, aws-trusted-advisor, aws-trusted-advisor-cost, aws-trusted-advisor-fault-tolerance, aws-trusted-advisor-security
+aws-vpc, aws-waf, azure, azure-aci, azure-acl, azure-acr, azure-activity-log, azure-ad
+azure-advisor, azure-aks, azure-api-management, azure-app-registration, azure-app-service, azure-application-gateway, azure-availability-set, azure-bastion
+azure-cdn, azure-container-app, azure-cosmos, azure-data-factory, azure-devops, azure-devops-pipeline, azure-disk, azure-disk-snapshot
+azure-dns, azure-enterprise-app, azure-event-hub, azure-firewall, azure-front-door, azure-function, azure-group, azure-image
+azure-ip, azure-key-vault, azure-key-vaults, azure-load-balancer, azure-load-balancers, azure-log-analytics, azure-logic-app, azure-managed-identity
+azure-metrics, azure-monitor, azure-nat, azure-network-interface, azure-postgres, azure-redis, azure-resource-group, azure-route-table
+azure-sentinel, azure-service-bus, azure-service-fabric, azure-sql-server, azure-static-web-app, azure-storage, azure-storage-container, azure-subscription
+azure-synapse, azure-traffic-manager, azure-user, azure-vm, azure-vm-scaleset, azure-vnet, azure-vpn, backstage
+badge, badge-check, badge-check2, badge-wait, ban, bazel, bell, bizagi
+block, bluelineconsole, bot, bot-broken, bot2, boundary, brain, broadcast
+broadcast2, broken-heart, browser, bug, c, c-sharp, ca, caddy
+cal, calico, canary-checker, canary-checker-white, cancel, casbin, cassandra, ceph
+cert-manager, certificate, cfg, changes, chatgpt, check, check-database, check-docker
+check-green, checkmark, checkout, cilium, cisco, classroom, claude, claude_logo
+clickhouse, clickhouse_logo, clock, clone, cloud-build, cloud-done, cloud-download, cloud-error
+cloud-fire, cloud-upload, cloudflare, cloudformation, cloudsql, cloudwatch, cloudwatch-alarm, cloudwatch-config
+cluster, cmake, cni, cnrm, cockroachdb, code, cog, compare
+compute-engine, config, config-db, config-db-white, confluence, connected, console, consul
+containerd, containerdPull, containerdPush, copilot, copilot_logo, coredns, cpp, cpu
+critical, cross, cross-o, crosshair, crossplane, crossplane-logo, csharp, csi
+css, csv, d365, dart, dashboard-line, data-center, data-grid, data-transfer
+database, database-fill, database-fill-gear, database-plus, database-restore, database-search, database-search-o, databases
+databricks, datadog, datapower-monitoring, datapower-routing, dead, deb, debian, decrease
+default-file, deployment, details, dex, diff, discord, disk, disk-error
+disk-failed, disk-success, django, dns, dns2, docker, dockerPull, dockerPush
+docx, dollar, dotenv, dotnet, dots-triple, down, down-bordered, down-database
+down-shield, download, download-archive, download-cloud, dynatrace, ec2, ecr, edit
+edit-property, editorconfig, eks, elastic, elasticsearch, elb, elixir, email
+entra, entra-conditional-access, entra-connect, envoy, envoy-gateway, erlang, error, error-circle-outline
+error-database, error-diamond, error-network-card, etcd, exchange, expired, export, external-sercrets
+fail, falco, fastly, file-loop, filter, fire, firewall, flagger
+flanksource, flanksource-icon, flow2, fluentd, flux, folder, folder-git, folder-shared
+function, gcp, gcp-access-context-manager, gcp-administration, gcp-advanced-agent-modeling, gcp-advanced-solutions-lab, gcp-agent-assist, gcp-ai-hub
+gcp-ai-platform, gcp-ai-platform-unified, gcp-analytics-hub, gcp-anthos, gcp-anthos-config-management, gcp-anthos-service-mesh, gcp-api, gcp-api-analytics
+gcp-api-monetization, gcp-apigee-api-platform, gcp-apigee-sense, gcp-app-engine, gcp-artifact-registry, gcp-asset-inventory, gcp-assured-workloads, gcp-automl
+gcp-automl-natural-language, gcp-automl-tables, gcp-automl-translation, gcp-automl-video-intelligence, gcp-automl-vision, gcp-bare-metal-solutions, gcp-batch, gcp-beyondcorp
+gcp-bigquery, gcp-bigtable, gcp-billing, gcp-binary-authorization, gcp-catalog, gcp-certificate-authority-service, gcp-certificate-manager, gcp-cloud-api-gateway
+gcp-cloud-apis, gcp-cloud-armor, gcp-cloud-asset-inventory, gcp-cloud-audit-logs, gcp-cloud-build, gcp-cloud-cdn, gcp-cloud-code, gcp-cloud-composer
+gcp-cloud-data-fusion, gcp-cloud-deploy, gcp-cloud-deployment-manager, gcp-cloud-dns, gcp-cloud-domains, gcp-cloud-ekm, gcp-cloud-endpoints, gcp-cloud-external-ip-addresses
+gcp-cloud-firewall-rules, gcp-cloud-for-marketing, gcp-cloud-functions, gcp-cloud-generic, gcp-cloud-gpu, gcp-cloud-healthcare-api, gcp-cloud-healthcare-marketplace, gcp-cloud-hsm
+gcp-cloud-ids, gcp-cloud-inference-api, gcp-cloud-interconnect, gcp-cloud-jobs-api, gcp-cloud-load-balancing, gcp-cloud-logging, gcp-cloud-media-edge, gcp-cloud-monitoring
+gcp-cloud-nat, gcp-cloud-natural-language-api, gcp-cloud-network, gcp-cloud-ops, gcp-cloud-optimization-ai, gcp-cloud-optimization-ai---fleet-routing-api, gcp-cloud-router, gcp-cloud-routes
+gcp-cloud-run, gcp-cloud-run-for-anthos, gcp-cloud-scheduler, gcp-cloud-security-scanner, gcp-cloud-shell, gcp-cloud-spanner, gcp-cloud-sql, gcp-cloud-storage
+gcp-cloud-tasks, gcp-cloud-test-lab, gcp-cloud-tpu, gcp-cloud-translation-api, gcp-cloud-vision-api, gcp-cloud-vpn, gcp-compute-engine, gcp-configuration-management
+gcp-connectivity-test, gcp-connectors, gcp-contact-center-ai, gcp-container-optimized-os, gcp-container-registry, gcp-data-catalog, gcp-data-labeling, gcp-data-layers
+gcp-data-loss-prevention-api, gcp-data-qna, gcp-data-studio, gcp-data-transfer, gcp-database-migration-service, gcp-dataflow, gcp-datalab, gcp-dataplex
+gcp-datapol, gcp-dataprep, gcp-dataproc, gcp-dataproc-metastore, gcp-datashare, gcp-datastore, gcp-datastream, gcp-debugger
+gcp-developer-portal, gcp-dialogflow, gcp-dialogflow-cx, gcp-dialogflow-insights, gcp-document-ai, gcp-early-access-center, gcp-error-reporting, gcp-eventarc
+gcp-filestore, gcp-financial-services-marketplace, gcp-firestore, gcp-fleet-engine, gcp-free-trial, gcp-game-servers, gcp-gce-systems-management, gcp-genomics
+gcp-gke-on-prem, gcp-google-cloud-marketplace, gcp-google-kubernetes-engine, gcp-google-maps-platform, gcp-healthcare-nlp-api, gcp-home, gcp-identity-and-access-management, gcp-identity-aware-proxy
+gcp-identity-platform, gcp-iot-core, gcp-iot-edge, gcp-key-access-justifications, gcp-key-management-service, gcp-kms, gcp-kuberun, gcp-launcher
+gcp-local-ssd, gcp-looker, gcp-managed-service-for-microsoft-active-directory, gcp-media-translation-api, gcp-memorystore, gcp-migrate-for-anthos, gcp-migrate-for-compute-engine, gcp-my-cloud
+gcp-network-connectivity-center, gcp-network-intelligence-center, gcp-network-security, gcp-network-tiers, gcp-network-topology, gcp-onboarding, gcp-os-configuration-management, gcp-os-inventory-management
+gcp-os-patch-management, gcp-partner-interconnect, gcp-partner-portal, gcp-performance-dashboard, gcp-permissions, gcp-persistent-disk, gcp-phishing-protection, gcp-policy-analyzer
+gcp-premium-network-tier, gcp-private-connectivity, gcp-private-service-connect, gcp-producer-portal, gcp-profiler, gcp-project, gcp-pubsub, gcp-quantum-engine
+gcp-quotas, gcp-real-world-insights, gcp-recommendations-ai, gcp-release-notes, gcp-repos, gcp-retail-api, gcp-risk-manager, gcp-runtime-config
+gcp-secret-manager, gcp-security, gcp-security-command-center, gcp-security-health-advisor, gcp-security-key-enforcement, gcp-service-discovery, gcp-speech-to-text, gcp-stackdriver
+gcp-standard-network-tier, gcp-stream-suite, gcp-support, gcp-tensorflow-enterprise, gcp-text-to-speech, gcp-tools-for-powershell, gcp-trace, gcp-traffic-director
+gcp-transfer, gcp-transfer-appliance, gcp-user-preferences, gcp-vertex-ai, gcp-video-intelligence-api, gcp-virtual-private-cloud, gcp-visual-inspection, gcp-vmware-engine
+gcp-web-risk, gcp-web-security-scanner, gcp-workflows, gcp-workload-identity-pool, gcsBucket, gear, gemini, gif
+git, git-compare, git-merge-queue, git-pr, gitea, github, gitlab, gke
+globe1, go, goal, google, google-chat, google-cloud, gradle, grafana
+graphql, group, grpc, grpc2, gz, haproxy, harbor, haskell
+hazelcast, health, health2, heart, heart-checkmark, heart-monitor, heart-o, heart-pulse
+heart-question, helm, help, hibernate, hide, history, history-o, hourglass
+html, http, https, ibm, ibm-cloud, ibm-mq, icmp, id-not-verified
+id-verified, idea, ifttt, import, in-progress, incidents, increase, increase2
+infinity, influxdb, info, info-circle, info2, infoblox, ini, insights
+ip, istio, jaeger, jar, java, jenkins, jira, jmeter
+js, json, junit, jwt, k3s, k6, k8s, k8s-clusterrole
+k8s-clusterrolebinding, k8s-configmap, k8s-cronjob, k8s-customresourcedefinition, k8s-daemonset, k8s-deployment, k8s-endpoint, k8s-ep
+k8s-group, k8s-hpa, k8s-ingress, k8s-job, k8s-limits, k8s-namespace, k8s-netpol, k8s-networkpolicy
+k8s-node, k8s-persistentvolume, k8s-persistentvolumeclaim, k8s-pod, k8s-podsecuritypolicy, k8s-quota, k8s-replicaset, k8s-role
+k8s-rolebinding, k8s-secret, k8s-service, k8s-serviceaccount, k8s-statefulset, k8s-storageclass, k8s-user, k8s-vol
+kafka, karpenter, kasten, keda, keda-logo, keycloak, knative, kong
+kotlin, kubescape, kustomize, kyverno, lab, ldap, learning, letsencrypt
+library, lifebuoy, link, linkerd, linux, list, loadbalancer, loading-bar
+lock, log, logic-apps, login, logout, logs, logs2, loki
+longhorn, lua, makefile-icon, mariadb, markdown, matrix, mattermost, maven
+maximize, mcp, mem, memchache, memory-error, metallb, metrics, mfa
+microsoft, microsoft-copilot, minimize, minio, minus, mission-control, mission-control-logo, mission-control-logo-white
+mission-control-playbook, mission-control-white, mongo, mongodb, mqtt, msplanner, multiple, mysql
+namespace, nats, network, network-card, newrelic, next.js, nginx, nic
+nodejs, not-found, npm, ntfy, o365, ods, off, ok
+okta, ollama, on, opa, openai, opengitops, openid, opensearch
+openshift, opentelemetry, openvpn, operatorframework, opsgenie, oracle, oracle_icon, ory
+ory-hydra, ory-kratos, ory-logo, package-install, package-rollback, package-uninstall, package-upgrade, pagerduty
+pages, pass, pause, pause-button, pdf, pem, perl, php
+ping, playbook, playwright, plugin, plugin-o, plus, png, pod
+pom, portainer, postgres, postgres-white, postgrest, postman, power-off, powerbi
+powershell, ppt, pptx, priority-low, prisma, prometheus, properties-script, protobuf
+pushbullet, pushover, py, python, question, questions, r, rabbitmq
+radar, rancher, ratio, rb, react, realtime, recycle, redhat
+redis, region, relationship, reload, remove, remove-alarm, remove-archive, remove-badge
+remove-certificate, remove-clock, remove-cloud, remove-comment, remove-cost, remove-database, remove-email, remove-filter
+remove-firewall, remove-folder, remove-group, remove-heart, remove-key, remove-link, remove-list, remove-network-card
+remove-node, remove-page, remove-shield, remove-silence, remove-tag, remove-ticket, remove-trash, remove-user
+replace, report-card, restart, restart-button, restic, restore, restrict, resume
+rocket, rocket-chat, rollback, rook, router, rub, ruby, rust
+samba, save, scala, scale-down, scale-in, scale-out, scale-up, schedule
+scorecard-fail, scylladb, seal, search, search-bar, search-box, search-in-list, security-pass
+send, sentry, server, servers, servers-outline, servers2, servicenow, servicenow-logo
+settings, sftp, shell, shield, shield-check, shield-help, shield-lock, shield-time
+shield-user, shield-warn, show, shutdown, silence, silenced, skip, slack
+sleep-mode, smb, sms, snail, snooze, snowflake, snyk, sonarqube
+source, speak, speed, split, split-o, splunk, spring, sql
+sql-server, sqlserver, ssl, ssl2, stackdriver, stackdriver-monitoring, stackdriver-trace, star
+start, start-cog, stop, stopwatch, structure, submit-for-approval, supabase, svelte
+swagger, swift, switch, sync, sys, system, system-report, tag
+tag2, tailscale, talk, target, target2, teams, telegram, temporal
+terraform, test, thanos, thousandeyes, timeout, timer, timescaledb, timezone
+today, toggle-off, toggle-on, tomcat, toml, topology, topology-white, traces
+traefik, trafficlight, training, training2, transfer, trash, tree, trivy
+troubleshoot, ts, txt, ubuntu, unhealthy, unlock, up, up-bordered
+up-database, up-shield, upload, user, vagrant, valkey, variable, variable2
+variable3, vault, vault2, vcluster, velero, victoriametrics, view-details, vip
+vpn, vscode, vsd, vsphere, vue, wait-for-approval, warning-circle, warning-circle2
+webhook, website, wireguard, workflow, workflow-o, world, www, xls
+xlsx, xml, yaml, zip, zulip
+
+## @flanksource/icons-ui Components (450)
+
+UiAdd, UiAddFilled, UiArchive, UiArchiveFilled, UiArray, UiArrowDown
+UiArrowDownFilled, UiArrowLeft, UiArrowLeftFilled, UiArrowRight, UiArrowRightFilled, UiArrowUp
+UiArrowUpFilled, UiAsyncFn, UiAt, UiAtFilled, UiBeaker, UiBeakerFilled
+UiBell, UiBellFilled, UiBellSlash, UiBellSlashFilled, UiBinary, UiBinaryFilled
+UiBox, UiBoxes, UiBoxesFilled, UiBoxFilled, UiBraces, UiBrain
+UiBrainFilled, UiBroadcast, UiBroadcastFilled, UiBug, UiBugFilled, UiCalendar
+UiCalendarBlank, UiCalendarBlankFilled, UiCalendarFilled, UiCamera, UiCameraFilled, UiCancel
+UiCancelFilled, UiChartBar, UiChartBarFilled, UiChartPie, UiChartPieFilled, UiCheck
+UiCheckFilled, UiChevronDown, UiChevronDownFilled, UiChevronRight, UiChevronRightFilled, UiChevronsDown
+UiChevronsDownFilled, UiChevronsUp, UiChevronsUpFilled, UiChevronUp, UiChevronUpFilled, UiChip
+UiChipFilled, UiCircleFilled, UiCircleFilledFilled, UiCircleOutline, UiCircleOutlineFilled, UiCircleX
+UiCircleXFilled, UiClass, UiClock, UiClockFilled, UiClose, UiCloseFilled
+UiCloud, UiCloudDownload, UiCloudDownloadFilled, UiCloudFilled, UiCode2, UiCode2Filled
+UiCog, UiCogFilled, UiCollapseAll, UiColumns, UiColumnsFilled, UiCommand
+UiCommandFilled, UiComment, UiConfig, UiConfigFilled, UiConstant, UiConstructor
+UiCopy, UiCopyFilled, UiDatabase, UiDatabaseCheck, UiDatabaseCheckFilled, UiDatabaseCross
+UiDatabaseCrossFilled, UiDatabaseDown, UiDatabaseDownFilled, UiDatabaseError, UiDatabaseErrorFilled, UiDatabaseFilled
+UiDatabaseInfo, UiDatabaseInfoFilled, UiDatabaseMinus, UiDatabaseMinusFilled, UiDatabasePending, UiDatabasePendingFilled
+UiDatabasePlus, UiDatabasePlusFilled, UiDatabaseTrash, UiDatabaseTrashFilled, UiDatabaseUp, UiDatabaseUpFilled
+UiDatabaseWarning, UiDatabaseWarningFilled, UiDebug, UiDebugFilled, UiDecorator, UiDiff
+UiDotsVertical, UiDotsVerticalFilled, UiDownload, UiDownloadFilled, UiEdit, UiEditFilled
+UiEllipsis, UiEllipsisFilled, UiEndpoint, UiEnum, UiEnumMember, UiEnvelope
+UiEnvelopeFilled, UiError, UiEvent, UiExpandAll, UiExport, UiExternalLink
+UiEye, UiEyeClosed, UiEyeClosedFilled, UiEyeFilled, UiField, UiFile
+UiFileCode, UiFileCodeFilled, UiFileFilled, UiFileJson, UiFileSpreadsheet, UiFileText
+UiFileTextFilled, UiFilter, UiFilterFilled, UiFingerprint, UiFingerprintFilled, UiFolder
+UiFolderFilled, UiFolderGit, UiFolderGit2, UiFolderGit2Filled, UiFolderGitFilled, UiForm
+UiFormFilled, UiFunction, UiFunctionSquare, UiFunctionSquareFilled, UiFunnelData, UiFunnelDataFilled
+UiGitBranch, UiGitBranchFilled, UiGitGraph, UiGitGraphFilled, UiGitMerge, UiGitMergeFilled
+UiGitPr, UiGitPrFilled, UiGlobe, UiGraph, UiGraphFilled, UiGrid
+UiGridFilled, UiHistory, UiHistoryFilled, UiHome, UiHomeFilled, UiHourglass
+UiHourglassFilled, UiHubot, UiHubotFilled, UiImage, UiImageFilled, UiImport
+UiInbox, UiInboxFilled, UiInfo, UiInfoFilled, UiInsightAvailability, UiInsightAvailabilityFilled
+UiInsightCompliance, UiInsightCost, UiInsightCostFilled, UiInsightIntegration, UiInsightPerformance, UiInsightPerformanceFilled
+UiInsightRecommendation, UiInsightRecommendationFilled, UiInsightReliability, UiInsightReliabilityFilled, UiInsightSecurity, UiInsightSecurityFilled
+UiInsightTechnicalDebt, UiInsightTechnicalDebtFilled, UiInterface, UiJson, UiKanban, UiKanbanFilled
+UiKey, UiKeyFilled, UiKeyword, UiLambda, UiLayoutDashboard, UiLayoutDashboardFilled
+UiLightbulb, UiLightbulbFilled, UiLink, UiLinkExternal, UiLinkExternalFilled, UiLinkFilled
+UiListFlat, UiListFlatFilled, UiListTree, UiListTreeFilled, UiLoader, UiLoaderFilled
+UiLocation, UiLocationFilled, UiLock, UiLockFilled, UiLockOpen, UiLockOpenFilled
+UiMagicWand, UiMagicWandFilled, UiMarkdown, UiMenu, UiMenuFilled, UiMethod
+UiModule, UiNamespace, UiNetwork, UiNetworkFilled, UiNull, UiNumeric
+UiObject, UiOperator, UiOrganization, UiOrganizationCheck, UiOrganizationCheckFilled, UiOrganizationCross
+UiOrganizationCrossFilled, UiOrganizationFilled, UiOrganizationMinus, UiOrganizationMinusFilled, UiOrganizationPlus, UiOrganizationPlusFilled
+UiPackage, UiPackageFilled, UiParameter, UiPass, UiPassFilled, UiPause
+UiPhone, UiPhoneFilled, UiPlay, UiPlaybook, UiProperty, UiPulse
+UiPulseFilled, UiPuzzle, UiPuzzleFilled, UiQuestion, UiQuestionFilled, UiQueue
+UiQueueFilled, UiRecord, UiRefresh, UiRefreshFilled, UiRemove, UiRemoveFilled
+UiRobotAi, UiRobotAiFilled, UiRocket, UiRocketFilled, UiRoute, UiRouteFilled
+UiRows, UiRowsFilled, UiSave, UiSaveFilled, UiSealCheck, UiSealCheckFilled
+UiSearch, UiSelect, UiSelectFilled, UiServer, UiServerProcess, UiServerProcessFilled
+UiSeverityBlocker, UiSeverityBlockerFilled, UiSeverityCritical, UiSeverityCriticalFilled, UiSeverityHigh, UiSeverityHighFilled
+UiSeverityInfo, UiSeverityInfoFilled, UiSeverityLow, UiSeverityLowFilled, UiSeverityMedium, UiSeverityMediumFilled
+UiSeverityWarning, UiSeverityWarningFilled, UiShare, UiShareFilled, UiShield, UiShieldCheck
+UiShieldCheckFilled, UiShieldCross, UiShieldCrossFilled, UiShieldFilled, UiShieldInfo, UiShieldInfoFilled
+UiShieldMinus, UiShieldMinusFilled, UiShieldPending, UiShieldPendingFilled, UiShieldPlus, UiShieldPlusFilled
+UiShieldWarning, UiShieldWarningFilled, UiShipWheel, UiSidebar, UiSidebarFilled, UiSignIn
+UiSignInFilled, UiSignOut, UiSignOutFilled, UiSiren, UiSirenFilled, UiSkipForward
+UiSkipForwardFilled, UiSkull, UiSkullFilled, UiSliders, UiSlidersFilled, UiSparkles
+UiSparklesFilled, UiSpeaker, UiSpeakerFilled, UiSqlArray, UiSqlColumn, UiSqlConstraint
+UiSqlDatabase, UiSqlForeignKey, UiSqlFunction, UiSqlIndex, UiSqlPrimaryKey, UiSqlQuery
+UiSqlSchema, UiSqlSequence, UiSqlStoredProc, UiSqlTable, UiSqlTableFilled, UiSqlTrigger
+UiSqlView, UiSquare, UiSquareFilled, UiStar, UiStarFilled, UiStop
+UiString, UiStruct, UiSwap, UiTable, UiTableFilled, UiTableProperties
+UiTablePropertiesFilled, UiTag, UiTagFilled, UiTerminal, UiTerminalFilled, UiTest
+UiThumbsDown, UiThumbsDownFilled, UiThumbsUp, UiThumbsUpFilled, UiToggleOff, UiToggleOffFilled
+UiToggleOn, UiToggleOnFilled, UiTrait, UiTrash, UiTrashFilled, UiTrendDown
+UiTrendDownFilled, UiTrendUp, UiTrendUpFilled, UiTypeAlias, UiTypeParameter, UiUnknown
+UiUpload, UiUploadFilled, UiUser, UiUserCheck, UiUserCheckFilled, UiUserCircle
+UiUserCircleCheck, UiUserCircleCheckFilled, UiUserCircleFilled, UiUserCircleMinus, UiUserCircleMinusFilled, UiUserCirclePlus
+UiUserCirclePlusFilled, UiUserFilled, UiUserMinus, UiUserMinusFilled, UiUserPlus, UiUserPlusFilled
+UiUsersThree, UiUsersThreeCheck, UiUsersThreeCheckFilled, UiUsersThreeCross, UiUsersThreeCrossFilled, UiUsersThreeFilled
+UiUsersThreeMinus, UiUsersThreeMinusFilled, UiUsersThreePlus, UiUsersThreePlusFilled, UiVariable, UiVideo
+UiVideoFilled, UiWarningCircle, UiWarningCircleFilled, UiWarningTriangle, UiWarningTriangleFilled, UiWatch
+UiWatchFilled, UiWorkflow, UiWrench, UiWrenchFilled, UiZap, UiZapFilled

--- a/make.sh
+++ b/make.sh
@@ -139,6 +139,7 @@ if [ -d "$icons_ui_dir" ]; then
   (cd "$icons_ui_dir" && pnpm install --silent && pnpm run build:codegen >/dev/null)
   icons_ui_alias="--alias:@flanksource/icons-ui=$icons_ui_dir/src/index.ts"
 fi
+node scripts/generate-llm-txt.mjs
 pnpm exec esbuild $reactIconsAll/DemoApp.tsx \
   --bundle --format=esm --jsx=automatic \
   --alias:@flanksource/icons/mi=$reactIconsAll/mi/index.mjs \

--- a/packages/ui/scripts/smoke-changes.mjs
+++ b/packages/ui/scripts/smoke-changes.mjs
@@ -1,0 +1,65 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import {
+  getChangeIcon,
+  changeIconAliases,
+  UiShieldCheck,
+  UiShieldWarning,
+  UiShieldInfo,
+  UiShieldCheckFilled,
+  UiShieldWarningFilled,
+  UiShieldInfoFilled,
+  UiDatabaseUp,
+  UiDatabaseDown,
+} from "../dist/index.mjs";
+
+console.log("=== changeIconAliases entries ===");
+const names = Object.keys(changeIconAliases).sort();
+console.log("  total:", names.length);
+console.log("  sample:", names.slice(0, 8).join(", "));
+
+console.log("\n=== getChangeIcon resolves canonical change types ===");
+for (const [name, expectedTarget] of [
+  ["BackupStarted", "UiDatabaseUp"],
+  ["BackupRestored", "UiDatabaseDown"],
+  ["BackupFailed", "UiDatabaseError"],
+  ["CREATE", "UiAdd"],
+  ["UPDATE", "UiEdit"],
+  ["DELETE", "UiTrash"],
+  ["GroupMemberAdded", "UiUsersThreePlus"],
+  ["Approved", "UiPass"],
+  ["Rejected", "UiCircleX"],
+  ["Pulled", "UiCloudDownload"],
+  ["Promotion", "UiArrowRight"],
+  ["CertificateExpired", "UiShieldWarning"],
+  ["NotARealType", null],
+]) {
+  const Comp = getChangeIcon(name);
+  const display = Comp ? Comp.displayName : null;
+  const ok = expectedTarget === null ? Comp === undefined : display === expectedTarget;
+  console.log(`  ${name.padEnd(26)} → ${display ?? "undefined"}  ${ok ? "✓" : "✗ expected " + expectedTarget}`);
+}
+
+console.log("\n=== Filled lookup ===");
+const filledBackup = getChangeIcon("BackupStarted", { filled: true });
+console.log(`  BackupStarted (filled) → ${filledBackup?.displayName}  ${filledBackup?.displayName === "UiDatabaseUpFilled" ? "✓" : "✗"}`);
+
+console.log("\n=== Shield Check / Warning / Info as composites ===");
+for (const [name, Comp] of [
+  ["UiShieldCheck", UiShieldCheck],
+  ["UiShieldWarning", UiShieldWarning],
+  ["UiShieldInfo", UiShieldInfo],
+  ["UiShieldCheckFilled", UiShieldCheckFilled],
+  ["UiShieldWarningFilled", UiShieldWarningFilled],
+  ["UiShieldInfoFilled", UiShieldInfoFilled],
+]) {
+  const html = renderToStaticMarkup(createElement(Comp, { size: 32 }));
+  const hasMarker = html.includes("<g transform=");
+  const isFilled = name.endsWith("Filled");
+  const hasTintedBase = isFilled && /fill="(#[0-9a-f]{6})"/i.test(html);
+  console.log(`  ${name.padEnd(26)} ${html.length} bytes  marker=${hasMarker ? "✓" : "✗"}  ${isFilled ? `tinted=${hasTintedBase ? "✓" : "✗"}` : ""}`);
+}
+
+console.log("\n=== Database Up/Down still work ===");
+console.log(`  UiDatabaseUp source: ${UiDatabaseUp.__source}`);
+console.log(`  UiDatabaseDown source: ${UiDatabaseDown.__source}`);

--- a/packages/ui/scripts/smoke-defaults.mjs
+++ b/packages/ui/scripts/smoke-defaults.mjs
@@ -1,0 +1,66 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import {
+  UiSeverityCritical,
+  UiSeverityHigh,
+  UiSeverityMedium,
+  UiSeverityLow,
+  UiSeverityInfo,
+  UiSeverityWarning,
+  UiSeverityBlocker,
+  UiError,
+  UiWarningCircle,
+  UiWarningTriangle,
+  UiPass,
+  UiInfo,
+  UiSkull,
+  UiSiren,
+  UiChangeDiff,
+  UiDiff,
+  UiDatabasePlus,
+} from "../dist/index.mjs";
+
+console.log("=== Default colors (no overrides) ===");
+for (const [name, Comp, expected] of [
+  ["UiSeverityCritical", UiSeverityCritical, "#dc2626"],
+  ["UiSeverityHigh", UiSeverityHigh, "#ef4444"],
+  ["UiSeverityMedium", UiSeverityMedium, "#f59e0b"],
+  ["UiSeverityLow", UiSeverityLow, "#0ea5e9"],
+  ["UiSeverityInfo", UiSeverityInfo, "#64748b"],
+  ["UiSeverityWarning", UiSeverityWarning, "#d97706"],
+  ["UiSeverityBlocker", UiSeverityBlocker, "#b91c1c"],
+  ["UiError", UiError, "#dc2626"],
+  ["UiWarningCircle", UiWarningCircle, "#d97706"],
+  ["UiWarningTriangle", UiWarningTriangle, "#d97706"],
+  ["UiPass", UiPass, "#059669"],
+  ["UiInfo", UiInfo, "#0ea5e9"],
+  ["UiSkull", UiSkull, "#b91c1c"],
+  ["UiSiren", UiSiren, "#dc2626"],
+]) {
+  const html = renderToStaticMarkup(createElement(Comp, { size: 24 }));
+  const ok = html.includes(`color:${expected}`);
+  console.log(`  ${name.padEnd(22)} default=${expected}  ${ok ? "✓" : "✗ — got: " + html.slice(0, 200)}`);
+}
+
+console.log("\n=== Override via className text-* ===");
+const overrideHtml = renderToStaticMarkup(createElement(UiError, { size: 24, className: "text-slate-500" }));
+console.log(`  UiError className="text-slate-500" → has #dc2626? ${overrideHtml.includes("#dc2626") ? "✗ (still defaulted)" : "✓ (overridden)"}`);
+console.log(`  ${overrideHtml.slice(0, 180)}`);
+
+console.log("\n=== Override via style.color ===");
+const styleOverride = renderToStaticMarkup(createElement(UiError, { size: 24, style: { color: "blue" } }));
+console.log(`  UiError style={{color:"blue"}} → has #dc2626? ${styleOverride.includes("#dc2626") ? "✗" : "✓"}, has 'blue'? ${styleOverride.includes("blue") ? "✓" : "✗"}`);
+
+console.log("\n=== UiChangeDiff aliases UiDiff ===");
+const diffHtml = renderToStaticMarkup(createElement(UiDiff, { size: 24 }));
+const changeDiffHtml = renderToStaticMarkup(createElement(UiChangeDiff, { size: 24 }));
+console.log(`  UiDiff bytes:       ${diffHtml.length}`);
+console.log(`  UiChangeDiff bytes: ${changeDiffHtml.length}  (paths match: ${diffHtml.match(/d="[^"]+"/)?.[0] === changeDiffHtml.match(/d="[^"]+"/)?.[0] ? "✓" : "✗"})`);
+
+console.log("\n=== Sub-icon halo (should be fill='none' stroke='currentColor') ===");
+const dbPlusHtml = renderToStaticMarkup(createElement(UiDatabasePlus, { size: 32 }));
+const haloRing = dbPlusHtml.match(/<circle[^/]*fill="none"[^/]*stroke="currentColor"[^/]*\/>/);
+console.log(`  UiDatabasePlus halo ring present? ${haloRing ? "✓" : "✗"}`);
+console.log(`  ${haloRing ? haloRing[0] : "(no ring)"}`);
+const whiteFill = /<circle[^/]*fill="white"/.test(dbPlusHtml);
+console.log(`  UiDatabasePlus white halo present? ${whiteFill ? "✗ (still has white)" : "✓ (no white)"}`);

--- a/packages/ui/scripts/smoke-final.mjs
+++ b/packages/ui/scripts/smoke-final.mjs
@@ -1,0 +1,69 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import * as M from "../dist/index.mjs";
+
+console.log("=== Database new sub-icons (info/warning/error) ===");
+for (const name of ["UiDatabaseInfo", "UiDatabaseWarning", "UiDatabaseError",
+                    "UiDatabaseInfoFilled", "UiDatabaseWarningFilled", "UiDatabaseErrorFilled"]) {
+  const C = M[name];
+  if (!C) { console.log(`  ${name.padEnd(28)} ✗ MISSING`); continue; }
+  const html = renderToStaticMarkup(createElement(C, { size: 24 }));
+  console.log(`  ${name.padEnd(28)} ${html.length} bytes  marker=${html.includes("<g transform=") ? "✓" : "✗"}`);
+}
+
+console.log("\n=== Database Filled composites (3-spindle base) ===");
+for (const name of ["UiDatabaseFilled", "UiDatabasePlusFilled", "UiDatabaseCheckFilled",
+                    "UiDatabaseTrashFilled", "UiDatabasePendingFilled", "UiDatabaseErrorFilled"]) {
+  const C = M[name];
+  if (!C) { console.log(`  ${name.padEnd(28)} ✗ MISSING`); continue; }
+  const html = renderToStaticMarkup(createElement(C, { size: 24 }));
+  // ph:database-fill should produce stacked discs — check for >= 3 path/ellipse-like shapes.
+  console.log(`  ${name.padEnd(28)} ${html.length} bytes`);
+}
+
+console.log("\n=== change-backup-* aliases — should equal UiDatabase<x> ===");
+for (const [alias, target] of [
+  ["UiChangeBackupStarted", "UiDatabasePlus"],
+  ["UiChangeBackupCompleted", "UiDatabaseCheck"],
+  ["UiChangeBackupRestored", "UiDatabasePending"],
+  ["UiChangeBackupFailed", "UiDatabaseError"],
+  ["UiChangeBackupDeleted", "UiDatabaseTrash"],
+]) {
+  const A = M[alias], T = M[target];
+  const Af = M[alias + "Filled"], Tf = M[target + "Filled"];
+  if (!A || !T) { console.log(`  ${alias} → ${target}: missing alias=${!A} target=${!T}`); continue; }
+  const aHtml = renderToStaticMarkup(createElement(A, { size: 24 }));
+  const tHtml = renderToStaticMarkup(createElement(T, { size: 24 }));
+  const same = aHtml === tHtml;
+  let filledOk = "n/a";
+  if (Af && Tf) {
+    const afHtml = renderToStaticMarkup(createElement(Af, { size: 24 }));
+    const tfHtml = renderToStaticMarkup(createElement(Tf, { size: 24 }));
+    filledOk = afHtml === tfHtml ? "✓" : "✗";
+  }
+  console.log(`  ${alias.padEnd(24)} → ${target.padEnd(20)}  outline=${same ? "✓" : "✗"}  filled=${filledOk}`);
+}
+
+console.log("\n=== UiCheck filled — should be ph:check-circle-fill (circle), not square ===");
+const ckFilled = M.UiCheckFilled;
+if (ckFilled) {
+  const html = renderToStaticMarkup(createElement(ckFilled, { size: 24 }));
+  // ph:check-circle-fill source should mention "M128" (Phosphor circle paths) and have viewBox 0 0 256 256
+  console.log(`  __source: ${ckFilled.__source}`);
+  console.log(`  ${html.slice(0, 200)}...`);
+} else {
+  console.log("  ✗ UiCheckFilled missing");
+}
+
+console.log("\n=== UsersThree filled sub-icon variants ===");
+for (const name of ["UiUsersThree", "UiUsersThreeFilled",
+                    "UiUsersThreePlus", "UiUsersThreePlusFilled",
+                    "UiUsersThreeMinus", "UiUsersThreeMinusFilled",
+                    "UiUsersThreeCheck", "UiUsersThreeCheckFilled",
+                    "UiUsersThreeCross", "UiUsersThreeCrossFilled"]) {
+  const C = M[name];
+  if (!C) { console.log(`  ${name.padEnd(28)} ✗ MISSING`); continue; }
+  const html = renderToStaticMarkup(createElement(C, { size: 24 }));
+  const hasMarker = html.includes("<g transform=");
+  console.log(`  ${name.padEnd(28)} ${html.length} bytes  marker=${hasMarker ? "✓" : "—"}`);
+}

--- a/packages/ui/scripts/smoke-groups.mjs
+++ b/packages/ui/scripts/smoke-groups.mjs
@@ -1,0 +1,28 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import {
+  UiUsersThree, UiUsersThreePlus, UiUsersThreeMinus, UiUsersThreeCheck, UiUsersThreeCross,
+  UiUserCircle, UiUserCirclePlus, UiUserCircleMinus, UiUserCircleCheck,
+  UiOrganization, UiOrganizationPlus, UiOrganizationMinus, UiOrganizationCheck, UiOrganizationCross,
+} from "../dist/index.mjs";
+
+for (const [name, Comp] of [
+  ["UiUsersThree", UiUsersThree],
+  ["UiUsersThreePlus", UiUsersThreePlus],
+  ["UiUsersThreeMinus", UiUsersThreeMinus],
+  ["UiUsersThreeCheck", UiUsersThreeCheck],
+  ["UiUsersThreeCross", UiUsersThreeCross],
+  ["UiUserCircle", UiUserCircle],
+  ["UiUserCirclePlus", UiUserCirclePlus],
+  ["UiUserCircleMinus", UiUserCircleMinus],
+  ["UiUserCircleCheck", UiUserCircleCheck],
+  ["UiOrganization", UiOrganization],
+  ["UiOrganizationPlus", UiOrganizationPlus],
+  ["UiOrganizationMinus", UiOrganizationMinus],
+  ["UiOrganizationCheck", UiOrganizationCheck],
+  ["UiOrganizationCross", UiOrganizationCross],
+]) {
+  const html = renderToStaticMarkup(createElement(Comp, { size: 32, title: name }));
+  const hasMarker = html.includes("<g transform=");
+  console.log(`${name.padEnd(26)} ${html.length.toString().padStart(4)} bytes  marker=${hasMarker ? "✓" : "—"}`);
+}

--- a/packages/ui/scripts/smoke-shield-db.mjs
+++ b/packages/ui/scripts/smoke-shield-db.mjs
@@ -1,0 +1,34 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import * as M from "../dist/index.mjs";
+
+console.log("=== Database Up / Down sub-icons ===");
+for (const name of ["UiDatabaseUp", "UiDatabaseUpFilled", "UiDatabaseDown", "UiDatabaseDownFilled"]) {
+  const C = M[name];
+  if (!C) { console.log(`  ${name.padEnd(28)} ✗ MISSING`); continue; }
+  const html = renderToStaticMarkup(createElement(C, { size: 24 }));
+  const hasMarker = html.includes("<g transform=");
+  console.log(`  ${name.padEnd(28)} ${html.length} bytes  marker=${hasMarker ? "✓" : "✗"}`);
+}
+
+console.log("\n=== Shield outline composites (default mode: currentColor shield + colored marker) ===");
+for (const name of ["UiShieldPlus", "UiShieldMinus", "UiShieldCross", "UiShieldPending"]) {
+  const C = M[name];
+  const html = renderToStaticMarkup(createElement(C, { size: 24 }));
+  const hasTint = /(?<!current)color="(#[0-9a-f]+|red|green|blue)"/i.test(html);
+  console.log(`  ${name.padEnd(28)} ${html.length} bytes  tinted-base=${hasTint ? "(should be NO) ✗" : "✓ (no tint)"}`);
+}
+
+console.log("\n=== Shield Filled composites (tinted-base mode: shield = marker color, marker = white) ===");
+for (const name of ["UiShieldPlusFilled", "UiShieldMinusFilled", "UiShieldCrossFilled", "UiShieldPendingFilled"]) {
+  const C = M[name];
+  if (!C) { console.log(`  ${name.padEnd(28)} ✗ MISSING`); continue; }
+  const html = renderToStaticMarkup(createElement(C, { size: 24 }));
+  // tinted base → currentColor should be replaced with the recipe color (e.g. #16a34a/#dc2626/#d97706)
+  // marker glyph wrapper should have color="white"
+  const hasMarkerWhite = /color="white"/.test(html);
+  const hasCurrentColor = /currentColor/.test(html);
+  // The base path's fill should now be a hex color, not currentColor
+  console.log(`  ${name.padEnd(28)} ${html.length} bytes  marker-white=${hasMarkerWhite ? "✓" : "✗"}  has-currentColor=${hasCurrentColor ? "✗ (should be replaced)" : "✓"}`);
+  if (name === "UiShieldPlusFilled") console.log(`    ${html.slice(0, 220)}...`);
+}

--- a/packages/ui/scripts/smoke-subicons.mjs
+++ b/packages/ui/scripts/smoke-subicons.mjs
@@ -1,0 +1,48 @@
+// Smoke-test the new composite icons.
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import {
+  UiDatabase,
+  UiDatabasePlus,
+  UiDatabaseMinus,
+  UiDatabaseCheck,
+  UiDatabaseCross,
+  UiDatabaseTrash,
+  UiDatabasePending,
+  UiUser,
+  UiUserPlus,
+  UiUserMinus,
+  UiUserCheck,
+  UiShield,
+  UiShieldPlus,
+  UiShieldMinus,
+  UiShieldCross,
+  UiShieldPending,
+} from "../dist/index.mjs";
+
+const rows = [
+  ["UiDatabase", UiDatabase],
+  ["UiDatabasePlus", UiDatabasePlus],
+  ["UiDatabaseMinus", UiDatabaseMinus],
+  ["UiDatabaseCheck", UiDatabaseCheck],
+  ["UiDatabaseCross", UiDatabaseCross],
+  ["UiDatabaseTrash", UiDatabaseTrash],
+  ["UiDatabasePending", UiDatabasePending],
+  ["UiUser", UiUser],
+  ["UiUserPlus", UiUserPlus],
+  ["UiUserMinus", UiUserMinus],
+  ["UiUserCheck", UiUserCheck],
+  ["UiShield", UiShield],
+  ["UiShieldPlus", UiShieldPlus],
+  ["UiShieldMinus", UiShieldMinus],
+  ["UiShieldCross", UiShieldCross],
+  ["UiShieldPending", UiShieldPending],
+];
+for (const [name, Comp] of rows) {
+  const html = renderToStaticMarkup(createElement(Comp, { size: 32, title: name }));
+  // Confirm the marker overlay exists for composites.
+  const hasMarker = name === "UiDatabase" || name === "UiUser" || name === "UiShield"
+    ? true // base icons have no marker
+    : html.includes("<g transform=");
+  console.log(`${name.padEnd(22)} ${html.length.toString().padStart(4)} bytes  marker=${hasMarker ? "✓" : "✗"}`);
+}

--- a/scripts/generate-llm-txt.mjs
+++ b/scripts/generate-llm-txt.mjs
@@ -1,0 +1,117 @@
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const svgDir = join(repoRoot, "svg");
+const iconsUiIndex = join(repoRoot, "packages", "ui", "src", "index.ts");
+const outPath = join(repoRoot, "llm.txt");
+
+async function readSvgIconNames() {
+  const files = await readdir(svgDir);
+  return files
+    .filter((file) => file.endsWith(".svg"))
+    .map((file) => file.slice(0, -".svg".length))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+async function readIconsUiNames() {
+  const source = await readFile(iconsUiIndex, "utf8");
+  const names = new Set();
+
+  for (const line of source.split(/\r?\n/)) {
+    const match = line.match(/^export \{ ([A-Za-z0-9_]+) \} from "\.\/icons\//);
+    if (match) names.add(match[1]);
+  }
+
+  return [...names].sort((a, b) => a.localeCompare(b));
+}
+
+function wrapList(names, perLine = 8) {
+  const lines = [];
+  for (let i = 0; i < names.length; i += perLine) {
+    lines.push(names.slice(i, i + perLine).join(", "));
+  }
+  return lines.join("\n");
+}
+
+function render(iconNames, iconsUiNames) {
+  return `# Flanksource Icons LLM Usage
+
+This file is generated from the Flanksource Icons repository for LLMs and coding agents.
+Use exact icon names from the listings below when generating code.
+
+Demo: https://flanksource.github.io/flanksource-icons/
+Repository: https://github.com/flanksource/flanksource-icons
+NPM packages: @flanksource/icons, @flanksource/icons-ui
+
+## Install
+
+\`\`\`sh
+pnpm add @flanksource/icons @flanksource/icons-ui
+\`\`\`
+
+Both packages require React as a peer dependency.
+
+## Choose The Right Component
+
+- Use @flanksource/icons/icon Icon when you know a curated SVG icon name.
+- Use ResourceIcon when the icon name comes from runtime data such as resource type, cloud provider, service, or config class.
+- Use FileTypeIcon when rendering file names or file extensions.
+- Use @flanksource/icons-ui components for UI actions, status, navigation, and product interface symbols.
+
+## Usage Examples
+
+\`\`\`tsx
+import { Icon, ResourceIcon, FileTypeIcon } from "@flanksource/icons/icon";
+
+export function Examples() {
+  return (
+    <>
+      <Icon name="aws-ec2" className="h-6 max-w-6" />
+      <Icon name="k8s-pod" color="blue" />
+      <ResourceIcon primary="Kubernetes::Pod" secondary="KubernetesResource" className="h-6 max-w-6" />
+      <ResourceIcon primary="datadog" className="h-6 max-w-6" />
+      <FileTypeIcon name="config.yaml" className="h-6 max-w-6" />
+    </>
+  );
+}
+\`\`\`
+
+\`\`\`tsx
+import { UiCheck, UiUpload, UiSearch, UiWarningCircleFilled } from "@flanksource/icons-ui";
+
+export function Toolbar() {
+  return (
+    <>
+      <UiSearch size={16} className="text-slate-700" />
+      <UiUpload size={16} />
+      <UiCheck size={16} className="text-emerald-600" title="complete" />
+      <UiWarningCircleFilled size={16} className="text-amber-600" />
+    </>
+  );
+}
+\`\`\`
+
+## Resolution Notes
+
+Icon accepts exact names from the @flanksource/icons listing and also supports the aliases and prefix matching built into the package.
+ResourceIcon first checks bundled icons, then falls back to allowed Iconify logo/devicon matches when enabled.
+FileTypeIcon maps common filenames and extensions to bundled icons.
+Most @flanksource/icons-ui outline icons use currentColor, so CSS color utilities such as className="text-blue-500" work.
+
+## @flanksource/icons Names (${iconNames.length})
+
+${wrapList(iconNames)}
+
+## @flanksource/icons-ui Components (${iconsUiNames.length})
+
+${wrapList(iconsUiNames, 6)}
+`;
+}
+
+const iconNames = await readSvgIconNames();
+const iconsUiNames = await readIconsUiNames();
+await writeFile(outPath, render(iconNames, iconsUiNames));
+
+console.log(`Generated llm.txt with ${iconNames.length} icon names and ${iconsUiNames.length} UI components.`);


### PR DESCRIPTION
**What**
- Generate `llm.txt` file with curated icon names and UI component listings for LLM/AI agent consumption
- Add 'LLM Usage' tab to demo app with copy-ready code examples
- Update build scripts and deployment to include `llm.txt` in dist output

**Why**
- Enables LLMs and AI agents to reference exact icon/component names when generating code
- Improves accuracy and reduces hallucination in generated code

**Notes**
- Added flex-wrap to tabs styling to accommodate new tab