### PR TITLE
feat(icons-ui): reorganize as subpath export and add filtering

### DIFF
--- a/.gavel.yaml
+++ b/.gavel.yaml
@@ -3,9 +3,14 @@ commit:
   - comparison.html
   compatibility: {}
   linkedDeps: {}
+  lint: {}
   precommit: {}
+  tidy: {}
 fixtures: {}
-lint: {}
+lint:
+  ignore:
+  - rule: omar-oracle-mention
+    source: betterleaks
 secrets: {}
 ssh: {}
 verify:

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ icons-list.js
 aliases.js
 prefixes.js
 !comparison.html
+react-icons/

--- a/DemoApp.tsx
+++ b/DemoApp.tsx
@@ -10,7 +10,7 @@ import { isWideViewBox } from "./iconBase";
 // inlines every component into the demo bundle. Falls back to an empty
 // namespace if the package wasn't built (rare: only when running the demo
 // outside the standard build).
-import * as IconsUi from "@flanksource/icons-ui";
+import * as IconsUi from "@flanksource/icons/ui";
 
 function isWideName(name: string | undefined, secondary?: string): boolean {
   const lookup = (n?: string) => (n ? findByName(n, IconMap) : undefined);
@@ -443,32 +443,73 @@ function Browse({ onSelect }: { onSelect: (name: string) => void }) {
 // Build a stable list of base names (outline variants without the "Filled"
 // suffix). For each base we record whether a Filled twin exists so the
 // browser can offer the variant toggle per icon.
-type IconsUiEntry = { name: string; outline?: React.FC<any>; filled?: React.FC<any> };
+type IconsUiComponent = React.FC<any> & {
+  __group?: string;
+  __source?: string;
+  __consumerName?: string;
+};
+type IconsUiEntry = {
+  name: string;
+  category: string;
+  outline?: IconsUiComponent;
+  filled?: IconsUiComponent;
+};
+
+function componentCategory(fn: unknown): string {
+  if (typeof fn !== "function") return "uncategorized";
+  return (fn as IconsUiComponent).__group || "uncategorized";
+}
+
+function humanizeCategory(category: string): string {
+  return category
+    .split("-")
+    .map((part) => part ? part[0].toUpperCase() + part.slice(1) : part)
+    .join(" ");
+}
+
 const iconsUiEntries: IconsUiEntry[] = (() => {
   const map = new Map<string, IconsUiEntry>();
   for (const [exportName, fn] of Object.entries(IconsUi)) {
     if (typeof fn !== "function") continue; // skip type-only re-exports
     if (exportName.endsWith("Filled")) {
       const base = exportName.slice(0, -"Filled".length);
-      const e = map.get(base) ?? { name: base };
-      e.filled = fn as React.FC<any>;
+      const e = map.get(base) ?? { name: base, category: componentCategory(fn) };
+      e.filled = fn as IconsUiComponent;
+      e.category = e.category || componentCategory(fn);
       map.set(base, e);
     } else {
-      const e = map.get(exportName) ?? { name: exportName };
-      e.outline = fn as React.FC<any>;
+      const e = map.get(exportName) ?? { name: exportName, category: componentCategory(fn) };
+      e.outline = fn as IconsUiComponent;
+      e.category = componentCategory(fn);
       map.set(exportName, e);
     }
   }
   return [...map.values()].sort((a, b) => a.name.localeCompare(b.name));
 })();
 
+const iconsUiCategories = (() => {
+  const counts = new Map<string, number>();
+  for (const entry of iconsUiEntries) counts.set(entry.category, (counts.get(entry.category) ?? 0) + 1);
+  return [...counts.entries()]
+    .map(([category, count]) => ({ category, count }))
+    .sort((a, b) => humanizeCategory(a.category).localeCompare(humanizeCategory(b.category)));
+})();
+
 function IconsUiBrowse({ onSelect }: { onSelect: (name: string) => void }) {
   const [search, setSearch] = useState("");
   const [variant, setVariant] = useState<"outline" | "filled">("outline");
+  const [category, setCategory] = useState("all");
   const filtered = useMemo(
     () =>
-      iconsUiEntries.filter((e) => e.name.toLowerCase().includes(search.toLowerCase())),
-    [search],
+      iconsUiEntries.filter((e) => {
+        const q = search.toLowerCase();
+        const matchesCategory = category === "all" || e.category === category;
+        const matchesSearch =
+          e.name.toLowerCase().includes(q) ||
+          e.category.toLowerCase().includes(q);
+        return matchesCategory && matchesSearch;
+      }),
+    [category, search],
   );
   return (
     <div className="card">
@@ -477,7 +518,7 @@ function IconsUiBrowse({ onSelect }: { onSelect: (name: string) => void }) {
           type="text"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search icons-ui (UiCheck, UiUpload, UiClass, …)"
+          placeholder="Search UI icons (UiCheck, UiUpload, UiClass, …)"
         />
         <span id="iconCount">
           {filtered.length} / {iconsUiEntries.length}
@@ -495,6 +536,27 @@ function IconsUiBrowse({ onSelect }: { onSelect: (name: string) => void }) {
             </button>
           ))}
         </div>
+      </div>
+      <div className="color-swatches" style={{ marginBottom: 12, alignItems: "center" }}>
+        <button
+          type="button"
+          className={`tab ${category === "all" ? "active" : ""}`}
+          style={{ padding: "4px 10px", fontSize: 12 }}
+          onClick={() => setCategory("all")}
+        >
+          All ({iconsUiEntries.length})
+        </button>
+        {iconsUiCategories.map((c) => (
+          <button
+            key={c.category}
+            type="button"
+            className={`tab ${category === c.category ? "active" : ""}`}
+            style={{ padding: "4px 10px", fontSize: 12 }}
+            onClick={() => setCategory(c.category)}
+          >
+            {humanizeCategory(c.category)} ({c.count})
+          </button>
+        ))}
       </div>
       <div style={{ fontSize: 12, color: "#666", marginBottom: 12, lineHeight: 1.5 }}>
         Generated from <code>hack/icon-selections.json</code>. Click any icon to open the
@@ -519,6 +581,9 @@ function IconsUiBrowse({ onSelect }: { onSelect: (name: string) => void }) {
               <Comp width={40} height={40} />
               <div className="icon-name" style={{ fontFamily: "'SF Mono', Monaco, monospace" }}>
                 {entry.name}
+              </div>
+              <div style={{ fontSize: 10, color: "#777", marginTop: 4 }}>
+                {humanizeCategory(entry.category)}
               </div>
             </div>
           );
@@ -589,7 +654,7 @@ function IconsUiDetail({ name, onBack, onOpen }: { name: string; onBack: () => v
   const importedNames = [entry.outline ? entry.name : null, entry.filled ? `${entry.name}Filled` : null]
     .filter(Boolean)
     .join(", ");
-  const importLine = `import { ${importedNames} } from "@flanksource/icons-ui";`;
+  const importLine = `import { ${importedNames} } from "@flanksource/icons/ui";`;
 
   const colorPreset = COLOR_PRESETS[colorIdx];
   const colorSpec = customColor.trim() || colorPreset.css || "currentColor";
@@ -616,6 +681,7 @@ function IconsUiDetail({ name, onBack, onOpen }: { name: string; onBack: () => v
   // Source attribution metadata is attached by the codegen on the underlying
   // function. `Object.assign` preserves the static field.
   const sourceMeta = (Comp as any).__source ?? "(unknown)";
+  const categoryMeta = entry.category;
 
   return (
     <div className="card">
@@ -634,6 +700,18 @@ function IconsUiDetail({ name, onBack, onOpen }: { name: string; onBack: () => v
           title={`Upstream: ${sourceMeta}`}
         >
           {sourceMeta}
+        </span>
+        <span
+          style={{
+            fontSize: 11,
+            padding: "2px 8px",
+            background: "#eef2ff",
+            color: "#4338ca",
+            borderRadius: 999,
+          }}
+          title={`Category: ${categoryMeta}`}
+        >
+          {humanizeCategory(categoryMeta)}
         </span>
       </div>
 
@@ -844,6 +922,41 @@ function IconsUiDetail({ name, onBack, onOpen }: { name: string; onBack: () => v
             );
           })()}
 
+          {(() => {
+            const related = iconsUiEntries
+              .filter((e) => e.name !== entry.name && e.category === entry.category)
+              .slice(0, 12);
+            if (related.length === 0) return null;
+            return (
+              <div style={{ marginTop: 16 }}>
+                <div style={{ fontSize: 12, color: "#666", marginBottom: 8, fontWeight: 600 }}>
+                  More in {humanizeCategory(entry.category)}
+                </div>
+                <div style={{ display: "flex", gap: 12, alignItems: "flex-end", padding: 16, background: "#fafafa", borderRadius: 6, flexWrap: "wrap" }}>
+                  {related.map((v) => {
+                    const VComp = v.outline ?? v.filled;
+                    if (!VComp) return null;
+                    return (
+                      <div
+                        key={v.name}
+                        style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 4, cursor: "pointer", padding: 6, borderRadius: 4 }}
+                        onClick={() => onOpen(v.name)}
+                        onMouseEnter={(e) => (e.currentTarget.style.background = "#eef2ff")}
+                        onMouseLeave={(e) => (e.currentTarget.style.background = "transparent")}
+                        title={`Click to open ${v.name}`}
+                      >
+                        <VComp width={28} height={28} />
+                        <span style={{ fontSize: 10, color: "#374151", fontFamily: "'SF Mono', Monaco, monospace" }}>
+                          {v.name.replace(/^Ui/, "")}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            );
+          })()}
+
           <div style={{ marginTop: 16 }}>
             <div style={{ fontSize: 12, color: "#666", marginBottom: 8, fontWeight: 600, display: "flex", justifyContent: "space-between", alignItems: "center" }}>
               <span>Raw SVG ({svgString.length} bytes)</span>
@@ -896,7 +1009,7 @@ function LlmUsage() {
       <p style={{ color: "#555", lineHeight: 1.6 }}>
         Use <a href="llm.txt" target="_blank" rel="noopener noreferrer">llm.txt</a>{" "}
         for copy-ready examples and complete generated listings of{" "}
-        <code>@flanksource/icons</code> names and <code>@flanksource/icons-ui</code>{" "}
+        <code>@flanksource/icons</code> names and <code>@flanksource/icons/ui</code>{" "}
         components.
       </p>
 
@@ -938,7 +1051,7 @@ function LlmUsage() {
             Use the {iconsUiEntries.length} generated React components for interface controls and states.
           </div>
           <div className="code-snippet" style={{ fontSize: 12 }}>
-            {'import { UiCheck, UiSearch, UiUpload } from "@flanksource/icons-ui";\n\n<UiSearch size={16} className="text-slate-700" />\n<UiCheck size={16} className="text-emerald-600" />\n<UiUpload size={16} />'}
+            {'import { UiCheck, UiSearch, UiUpload } from "@flanksource/icons/ui";\n\n<UiSearch size={16} className="text-slate-700" />\n<UiCheck size={16} className="text-emerald-600" />\n<UiUpload size={16} />'}
           </div>
         </div>
       </div>
@@ -968,7 +1081,7 @@ function App() {
       <p className="subtitle">
         ~{allIconNames.length} curated icons in <code>@flanksource/icons</code>{" "}
         + {iconsUiEntries.length} curated React components in{" "}
-        <code>@flanksource/icons-ui</code> &mdash;{" "}
+        <code>@flanksource/icons/ui</code> &mdash;{" "}
         <a href="https://github.com/flanksource/flanksource-icons">GitHub</a>{" "}
         &middot; <a href="llm.txt">llm.txt</a>
       </p>

--- a/hack/icon-selections.json
+++ b/hack/icon-selections.json
@@ -157,6 +157,78 @@
       "note": ""
     },
     {
+      "consumerName": "debug-small",
+      "group": "ui-controls",
+      "status": "NEW",
+      "outline": "codicon:debug-alt-small",
+      "filled": "skip",
+      "note": "Clicky UI compatibility: compact debug action icon"
+    },
+    {
+      "consumerName": "restart",
+      "group": "ui-controls",
+      "status": "NEW",
+      "outline": "codicon:debug-restart",
+      "filled": "skip",
+      "note": "Clicky UI compatibility: restart/debug restart"
+    },
+    {
+      "consumerName": "stack-frame-dot",
+      "group": "ui-controls",
+      "status": "NEW",
+      "outline": "codicon:debug-stackframe-dot",
+      "filled": "skip",
+      "note": "Clicky UI compatibility: active stack frame marker"
+    },
+    {
+      "consumerName": "debug-step-over",
+      "group": "ui-controls",
+      "status": "NEW",
+      "outline": "codicon:debug-step-over",
+      "filled": "skip",
+      "note": "Clicky UI compatibility: step-over/debug frame state"
+    },
+    {
+      "consumerName": "play-circle",
+      "group": "ui-controls",
+      "status": "NEW",
+      "outline": "ph:play-circle-light",
+      "filled": "ph:play-circle-fill",
+      "note": "Clicky UI compatibility: running/process state"
+    },
+    {
+      "consumerName": "resize-vertical",
+      "group": "ui-controls",
+      "status": "NEW",
+      "outline": "ph:arrows-in-line-vertical-light",
+      "filled": "ph:arrows-in-line-vertical-fill",
+      "note": "Clicky UI compatibility: row density/resize control"
+    },
+    {
+      "consumerName": "list-dashes",
+      "group": "ui-controls",
+      "status": "NEW",
+      "outline": "ph:list-dashes-light",
+      "filled": "ph:list-dashes-fill",
+      "note": "Clicky UI compatibility: spacious list density"
+    },
+    {
+      "consumerName": "activity",
+      "group": "ui-controls",
+      "status": "NEW",
+      "outline": "lucide:activity",
+      "filled": "skip",
+      "note": "Clicky UI compatibility: metric/activity badge"
+    },
+    {
+      "consumerName": "sync",
+      "group": "ui-controls",
+      "status": "NEW",
+      "outline": "codicon:sync",
+      "filled": "skip",
+      "note": "Clicky UI compatibility: sync/wait frame state"
+    },
+    {
       "consumerName": "arrow-down-right",
       "group": "ui-controls",
       "status": "NEW",

--- a/llm.txt
+++ b/llm.txt
@@ -5,12 +5,12 @@ Use exact icon names from the listings below when generating code.
 
 Demo: https://flanksource.github.io/flanksource-icons/
 Repository: https://github.com/flanksource/flanksource-icons
-NPM packages: @flanksource/icons, @flanksource/icons-ui
+NPM package: @flanksource/icons
 
 ## Install
 
 ```sh
-pnpm add @flanksource/icons @flanksource/icons-ui
+pnpm add @flanksource/icons
 ```
 
 Both packages require React as a peer dependency.
@@ -20,7 +20,7 @@ Both packages require React as a peer dependency.
 - Use @flanksource/icons/icon Icon when you know a curated SVG icon name.
 - Use ResourceIcon when the icon name comes from runtime data such as resource type, cloud provider, service, or config class.
 - Use FileTypeIcon when rendering file names or file extensions.
-- Use @flanksource/icons-ui components for UI actions, status, navigation, and product interface symbols.
+- Use @flanksource/icons/ui components for UI actions, status, navigation, and product interface symbols.
 
 ## Usage Examples
 
@@ -41,7 +41,7 @@ export function Examples() {
 ```
 
 ```tsx
-import { UiCheck, UiUpload, UiSearch, UiWarningCircleFilled } from "@flanksource/icons-ui";
+import { UiCheck, UiUpload, UiSearch, UiWarningCircleFilled } from "@flanksource/icons/ui";
 
 export function Toolbar() {
   return (
@@ -60,7 +60,7 @@ export function Toolbar() {
 Icon accepts exact names from the @flanksource/icons listing and also supports the aliases and prefix matching built into the package.
 ResourceIcon first checks bundled icons, then falls back to allowed Iconify logo/devicon matches when enabled.
 FileTypeIcon maps common filenames and extensions to bundled icons.
-Most @flanksource/icons-ui outline icons use currentColor, so CSS color utilities such as className="text-blue-500" work.
+Most @flanksource/icons/ui outline icons use currentColor, so CSS color utilities such as className="text-blue-500" work.
 
 ## @flanksource/icons Names (1125)
 
@@ -206,94 +206,78 @@ vpn, vscode, vsd, vsphere, vue, wait-for-approval, warning-circle, warning-circl
 webhook, website, wireguard, workflow, workflow-o, world, www, xls
 xlsx, xml, yaml, zip, zulip
 
-UiAdd, UiAddFilled, UiArchive, UiArchiveFilled, UiArray, UiArrowDown
-UiArrowDownFilled, UiArrowDownRight, UiArrowLeft, UiArrowLeftFilled, UiArrowRight, UiArrowRightFilled
-UiArrowUp, UiArrowUpFilled, UiArrowUpRight, UiAsyncFn, UiAt, UiAtFilled
-UiBeaker, UiBeakerFilled, UiBell, UiBellFilled, UiBellSlash, UiBellSlashFilled
-UiBinary, UiBinaryFilled, UiBox, UiBoxes, UiBoxesFilled, UiBoxFilled
-UiBraces, UiBrain, UiBrainFilled, UiBroadcast, UiBroadcastFilled, UiBug
-UiBugFilled, UiCalculator, UiCalendar, UiCalendarBlank, UiCalendarBlankFilled, UiCalendarFilled
-UiCamera, UiCameraFilled, UiCancel, UiCancelFilled, UiChartBar, UiChartBarFilled
-UiChartPie, UiChartPieFilled, UiCheck, UiCheckFilled, UiChevronDown, UiChevronDownFilled
-UiChevronRight, UiChevronRightFilled, UiChevronsDown, UiChevronsDownFilled, UiChevronsUp, UiChevronsUpFilled
-UiChevronUp, UiChevronUpFilled, UiChip, UiChipFilled, UiCircleFilled, UiCircleFilledFilled
-UiCircleOutline, UiCircleOutlineFilled, UiCircleX, UiCircleXFilled, UiClass, UiClock
-UiClockFilled, UiClose, UiCloseFilled, UiCloud, UiCloudDownload, UiCloudDownloadFilled
-UiCloudFilled, UiCode2, UiCode2Filled, UiCog, UiCogFilled, UiCollapseAll
-UiColumns, UiColumnsFilled, UiCommand, UiCommandFilled, UiComment, UiConfig
-UiConfigFilled, UiConstant, UiConstructor, UiCopy, UiCopyFilled, UiDatabase
-UiDatabaseCheck, UiDatabaseCheckFilled, UiDatabaseCross, UiDatabaseCrossFilled, UiDatabaseDown, UiDatabaseDownFilled
-UiDatabaseError, UiDatabaseErrorFilled, UiDatabaseFilled, UiDatabaseInfo, UiDatabaseInfoFilled, UiDatabaseMinus
-UiDatabaseMinusFilled, UiDatabasePending, UiDatabasePendingFilled, UiDatabasePlus, UiDatabasePlusFilled, UiDatabaseTrash
-UiDatabaseTrashFilled, UiDatabaseUp, UiDatabaseUpFilled, UiDatabaseWarning, UiDatabaseWarningFilled, UiDatabaseZap
-UiDebug, UiDebugFilled, UiDecorator, UiDesktop, UiDesktopFilled, UiDiff
-UiAdd, UiAddFilled, UiArchive, UiArchiveFilled, UiArray, UiArrowDown
-UiArrowDownFilled, UiArrowLeft, UiArrowLeftFilled, UiArrowRight, UiArrowRightFilled, UiArrowUp
-UiArrowUpFilled, UiAsyncFn, UiAt, UiAtFilled, UiBeaker, UiBeakerFilled
-UiBell, UiBellFilled, UiBellSlash, UiBellSlashFilled, UiBinary, UiBinaryFilled
-UiBox, UiBoxes, UiBoxesFilled, UiBoxFilled, UiBraces, UiBrain
-UiBrainFilled, UiBroadcast, UiBroadcastFilled, UiBug, UiBugFilled, UiCalendar
-UiCalendarBlank, UiCalendarBlankFilled, UiCalendarFilled, UiCamera, UiCameraFilled, UiCancel
-UiCancelFilled, UiChartBar, UiChartBarFilled, UiChartPie, UiChartPieFilled, UiCheck
-UiCheckFilled, UiChevronDown, UiChevronDownFilled, UiChevronRight, UiChevronRightFilled, UiChevronsDown
-UiChevronsDownFilled, UiChevronsUp, UiChevronsUpFilled, UiChevronUp, UiChevronUpFilled, UiChip
-UiChipFilled, UiCircleFilled, UiCircleFilledFilled, UiCircleOutline, UiCircleOutlineFilled, UiCircleX
-UiCircleXFilled, UiClass, UiClock, UiClockFilled, UiClose, UiCloseFilled
-UiCloud, UiCloudDownload, UiCloudDownloadFilled, UiCloudFilled, UiCode2, UiCode2Filled
-UiCog, UiCogFilled, UiCollapseAll, UiColumns, UiColumnsFilled, UiCommand
-UiCommandFilled, UiComment, UiConfig, UiConfigFilled, UiConstant, UiConstructor
-UiCopy, UiCopyFilled, UiDatabase, UiDatabaseCheck, UiDatabaseCheckFilled, UiDatabaseCross
-UiDatabaseCrossFilled, UiDatabaseDown, UiDatabaseDownFilled, UiDatabaseError, UiDatabaseErrorFilled, UiDatabaseFilled
-UiDatabaseInfo, UiDatabaseInfoFilled, UiDatabaseMinus, UiDatabaseMinusFilled, UiDatabasePending, UiDatabasePendingFilled
-UiDatabasePlus, UiDatabasePlusFilled, UiDatabaseTrash, UiDatabaseTrashFilled, UiDatabaseUp, UiDatabaseUpFilled
-UiDatabaseWarning, UiDatabaseWarningFilled, UiDebug, UiDebugFilled, UiDecorator, UiDiff
-UiDotsVertical, UiDotsVerticalFilled, UiDownload, UiDownloadFilled, UiEdit, UiEditFilled
-UiEllipsis, UiEllipsisFilled, UiEndpoint, UiEnum, UiEnumMember, UiEnvelope
-UiEnvelopeFilled, UiError, UiEvent, UiExpandAll, UiExport, UiExternalLink
-UiEye, UiEyeClosed, UiEyeClosedFilled, UiEyeFilled, UiField, UiFile
-UiFileCode, UiFileCodeFilled, UiFileCog, UiFileFilled, UiFileJson, UiFileSearch
-UiFileSpreadsheet, UiFileText, UiFileTextFilled, UiFileType, UiFilter, UiFilterFilled
-UiFingerprint, UiFingerprintFilled, UiFolder, UiFolderFilled, UiFolderGit, UiFolderGit2
-UiFolderGit2Filled, UiFolderGitFilled, UiForm, UiFormFilled, UiFullscreen, UiFullscreenFilled
-UiFunction, UiFunctionSquare, UiFunctionSquareFilled, UiFunnelData, UiFunnelDataFilled, UiGitBranch
-UiGitBranchFilled, UiGitGraph, UiGitGraphFilled, UiGitMerge, UiGitMergeFilled, UiGitPr
-UiGitPrFilled, UiGlobe, UiGraph, UiGraphFilled, UiGrid, UiGridFilled
-UiHardDrive, UiHistory, UiHistoryFilled, UiHome, UiHomeFilled, UiHourglass
-UiHourglassFilled, UiHubot, UiHubotFilled, UiImage, UiImageFilled, UiImport
-UiInbox, UiInboxFilled, UiInfo, UiInfoFilled, UiInsightAvailability, UiInsightAvailabilityFilled
-UiInsightCompliance, UiInsightCost, UiInsightCostFilled, UiInsightIntegration, UiInsightPerformance, UiInsightPerformanceFilled
-UiInsightRecommendation, UiInsightRecommendationFilled, UiInsightReliability, UiInsightReliabilityFilled, UiInsightSecurity, UiInsightSecurityFilled
-UiInsightTechnicalDebt, UiInsightTechnicalDebtFilled, UiInterface, UiJson, UiKanban, UiKanbanFilled
-UiKey, UiKeyFilled, UiKeyword, UiLambda, UiLayers, UiLayoutDashboard
-UiLayoutDashboardFilled, UiLightbulb, UiLightbulbFilled, UiLink, UiLinkExternal, UiLinkExternalFilled
-UiLinkFilled, UiListFlat, UiListFlatFilled, UiListOrdered, UiListTree, UiListTreeFilled
-UiLoader, UiLoaderFilled, UiLocation, UiLocationFilled, UiLock, UiLockFilled
-UiLockOpen, UiLockOpenFilled, UiMagicWand, UiMagicWandFilled, UiMarkdown, UiMemoryStick
-UiMenu, UiMenuFilled, UiMethod, UiModule, UiMoon, UiMoonFilled
-UiNamespace, UiNetwork, UiNetworkFilled, UiNull, UiNumeric, UiObject
-UiOperator, UiOrganization, UiOrganizationCheck, UiOrganizationCheckFilled, UiOrganizationCross, UiOrganizationCrossFilled
-UiOrganizationFilled, UiOrganizationMinus, UiOrganizationMinusFilled, UiOrganizationPlus, UiOrganizationPlusFilled, UiPackage
-UiPackageFilled, UiParameter, UiPass, UiPassFilled, UiPause, UiPhone
-UiPhoneFilled, UiPlay, UiPlaybook, UiPlug, UiProperty, UiPulse
-UiPulseFilled, UiPuzzle, UiPuzzleFilled, UiQuestion, UiQuestionFilled, UiQueue
-UiQueueFilled, UiRecord, UiRefresh, UiRefreshFilled, UiRemove, UiRemoveFilled
-UiRobotAi, UiRobotAiFilled, UiRocket, UiRocketFilled, UiRoute, UiRouteFilled
-UiRows, UiRowsFilled, UiSave, UiSaveFilled, UiScale, UiSealCheck
-UiSealCheckFilled, UiSearch, UiSelect, UiSelectFilled, UiServer, UiServerProcess
-UiServerProcessFilled, UiSeverityBlocker, UiSeverityBlockerFilled, UiSeverityCritical, UiSeverityCriticalFilled, UiSeverityHigh
-UiSeverityHighFilled, UiSeverityInfo, UiSeverityInfoFilled, UiSeverityLow, UiSeverityLowFilled, UiSeverityMedium
-UiSeverityMediumFilled, UiSeverityWarning, UiSeverityWarningFilled, UiShare, UiShareFilled, UiShield
-UiShieldCheck, UiShieldCheckFilled, UiShieldCross, UiShieldCrossFilled, UiShieldFilled, UiShieldInfo
-UiShieldInfoFilled, UiShieldMinus, UiShieldMinusFilled, UiShieldPending, UiShieldPendingFilled, UiShieldPlus
-UiShieldPlusFilled, UiShieldWarning, UiShieldWarningFilled, UiShipWheel, UiSidebar, UiSidebarFilled
-UiSigma, UiSignIn, UiSignInFilled, UiSignOut, UiSignOutFilled, UiSiren
-UiSirenFilled, UiSkipForward, UiSkipForwardFilled, UiSkull, UiSkullFilled, UiSliders
-UiSlidersFilled, UiSparkles, UiSparklesFilled, UiSpeaker, UiSpeakerFilled, UiSqlArray
-UiSqlColumn, UiSqlConstraint, UiSqlDatabase, UiSqlForeignKey, UiSqlFunction, UiSqlIndex
-UiSqlPrimaryKey, UiSqlQuery, UiSqlSchema, UiSqlSequence, UiSqlStoredProc, UiSqlTable
-UiSqlTableFilled, UiSqlTrigger, UiSqlView, UiSquare, UiSquareFilled, UiStar
-UiStarFilled, UiStop, UiString, UiStruct, UiSun, UiSunFilled
-UiSwap, UiTable, UiTableFilled, UiTableProperties, UiTablePropertiesFilled, UiTag
+## @flanksource/icons/ui Components (489)
+
+UiActivity, UiAdd, UiAddFilled, UiArchive, UiArchiveFilled, UiArray
+UiArrowDown, UiArrowDownFilled, UiArrowDownRight, UiArrowLeft, UiArrowLeftFilled, UiArrowRight
+UiArrowRightFilled, UiArrowUp, UiArrowUpFilled, UiArrowUpRight, UiAsyncFn, UiAt
+UiAtFilled, UiBeaker, UiBeakerFilled, UiBell, UiBellFilled, UiBellSlash
+UiBellSlashFilled, UiBinary, UiBinaryFilled, UiBox, UiBoxes, UiBoxesFilled
+UiBoxFilled, UiBraces, UiBrain, UiBrainFilled, UiBroadcast, UiBroadcastFilled
+UiBug, UiBugFilled, UiCalculator, UiCalendar, UiCalendarBlank, UiCalendarBlankFilled
+UiCalendarFilled, UiCamera, UiCameraFilled, UiCancel, UiCancelFilled, UiChartBar
+UiChartBarFilled, UiChartPie, UiChartPieFilled, UiCheck, UiCheckFilled, UiChevronDown
+UiChevronDownFilled, UiChevronRight, UiChevronRightFilled, UiChevronsDown, UiChevronsDownFilled, UiChevronsUp
+UiChevronsUpFilled, UiChevronUp, UiChevronUpFilled, UiChip, UiChipFilled, UiCircleFilled
+UiCircleFilledFilled, UiCircleOutline, UiCircleOutlineFilled, UiCircleX, UiCircleXFilled, UiClass
+UiClock, UiClockFilled, UiClose, UiCloseFilled, UiCloud, UiCloudDownload
+UiCloudDownloadFilled, UiCloudFilled, UiCode2, UiCode2Filled, UiCog, UiCogFilled
+UiCollapseAll, UiColumns, UiColumnsFilled, UiCommand, UiCommandFilled, UiComment
+UiConfig, UiConfigFilled, UiConstant, UiConstructor, UiCopy, UiCopyFilled
+UiDatabase, UiDatabaseCheck, UiDatabaseCheckFilled, UiDatabaseCross, UiDatabaseCrossFilled, UiDatabaseDown
+UiDatabaseDownFilled, UiDatabaseError, UiDatabaseErrorFilled, UiDatabaseFilled, UiDatabaseInfo, UiDatabaseInfoFilled
+UiDatabaseMinus, UiDatabaseMinusFilled, UiDatabasePending, UiDatabasePendingFilled, UiDatabasePlus, UiDatabasePlusFilled
+UiDatabaseTrash, UiDatabaseTrashFilled, UiDatabaseUp, UiDatabaseUpFilled, UiDatabaseWarning, UiDatabaseWarningFilled
+UiDatabaseZap, UiDebug, UiDebugFilled, UiDebugSmall, UiDebugStepOver, UiDecorator
+UiDesktop, UiDesktopFilled, UiDiff, UiDotsVertical, UiDotsVerticalFilled, UiDownload
+UiDownloadFilled, UiEdit, UiEditFilled, UiEllipsis, UiEllipsisFilled, UiEndpoint
+UiEnum, UiEnumMember, UiEnvelope, UiEnvelopeFilled, UiError, UiEvent
+UiExpandAll, UiExport, UiExternalLink, UiEye, UiEyeClosed, UiEyeClosedFilled
+UiEyeFilled, UiField, UiFile, UiFileCode, UiFileCodeFilled, UiFileCog
+UiFileFilled, UiFileJson, UiFileSearch, UiFileSpreadsheet, UiFileText, UiFileTextFilled
+UiFileType, UiFilter, UiFilterFilled, UiFingerprint, UiFingerprintFilled, UiFolder
+UiFolderFilled, UiFolderGit, UiFolderGit2, UiFolderGit2Filled, UiFolderGitFilled, UiForm
+UiFormFilled, UiFullscreen, UiFullscreenFilled, UiFunction, UiFunctionSquare, UiFunctionSquareFilled
+UiFunnelData, UiFunnelDataFilled, UiGitBranch, UiGitBranchFilled, UiGitGraph, UiGitGraphFilled
+UiGitMerge, UiGitMergeFilled, UiGitPr, UiGitPrFilled, UiGlobe, UiGraph
+UiGraphFilled, UiGrid, UiGridFilled, UiHardDrive, UiHistory, UiHistoryFilled
+UiHome, UiHomeFilled, UiHourglass, UiHourglassFilled, UiHubot, UiHubotFilled
+UiImage, UiImageFilled, UiImport, UiInbox, UiInboxFilled, UiInfo
+UiInfoFilled, UiInsightAvailability, UiInsightAvailabilityFilled, UiInsightCompliance, UiInsightCost, UiInsightCostFilled
+UiInsightIntegration, UiInsightPerformance, UiInsightPerformanceFilled, UiInsightRecommendation, UiInsightRecommendationFilled, UiInsightReliability
+UiInsightReliabilityFilled, UiInsightSecurity, UiInsightSecurityFilled, UiInsightTechnicalDebt, UiInsightTechnicalDebtFilled, UiInterface
+UiJson, UiKanban, UiKanbanFilled, UiKey, UiKeyFilled, UiKeyword
+UiLambda, UiLayers, UiLayoutDashboard, UiLayoutDashboardFilled, UiLightbulb, UiLightbulbFilled
+UiLink, UiLinkExternal, UiLinkExternalFilled, UiLinkFilled, UiListDashes, UiListDashesFilled
+UiListFlat, UiListFlatFilled, UiListOrdered, UiListTree, UiListTreeFilled, UiLoader
+UiLoaderFilled, UiLocation, UiLocationFilled, UiLock, UiLockFilled, UiLockOpen
+UiLockOpenFilled, UiMagicWand, UiMagicWandFilled, UiMarkdown, UiMemoryStick, UiMenu
+UiMenuFilled, UiMethod, UiModule, UiMoon, UiMoonFilled, UiNamespace
+UiNetwork, UiNetworkFilled, UiNull, UiNumeric, UiObject, UiOperator
+UiOrganization, UiOrganizationCheck, UiOrganizationCheckFilled, UiOrganizationCross, UiOrganizationCrossFilled, UiOrganizationFilled
+UiOrganizationMinus, UiOrganizationMinusFilled, UiOrganizationPlus, UiOrganizationPlusFilled, UiPackage, UiPackageFilled
+UiParameter, UiPass, UiPassFilled, UiPause, UiPhone, UiPhoneFilled
+UiPlay, UiPlaybook, UiPlayCircle, UiPlayCircleFilled, UiPlug, UiProperty
+UiPulse, UiPulseFilled, UiPuzzle, UiPuzzleFilled, UiQuestion, UiQuestionFilled
+UiQueue, UiQueueFilled, UiRecord, UiRefresh, UiRefreshFilled, UiRemove
+UiRemoveFilled, UiResizeVertical, UiResizeVerticalFilled, UiRestart, UiRobotAi, UiRobotAiFilled
+UiRocket, UiRocketFilled, UiRoute, UiRouteFilled, UiRows, UiRowsFilled
+UiSave, UiSaveFilled, UiScale, UiSealCheck, UiSealCheckFilled, UiSearch
+UiSelect, UiSelectFilled, UiServer, UiServerProcess, UiServerProcessFilled, UiSeverityBlocker
+UiSeverityBlockerFilled, UiSeverityCritical, UiSeverityCriticalFilled, UiSeverityHigh, UiSeverityHighFilled, UiSeverityInfo
+UiSeverityInfoFilled, UiSeverityLow, UiSeverityLowFilled, UiSeverityMedium, UiSeverityMediumFilled, UiSeverityWarning
+UiSeverityWarningFilled, UiShare, UiShareFilled, UiShield, UiShieldCheck, UiShieldCheckFilled
+UiShieldCross, UiShieldCrossFilled, UiShieldFilled, UiShieldInfo, UiShieldInfoFilled, UiShieldMinus
+UiShieldMinusFilled, UiShieldPending, UiShieldPendingFilled, UiShieldPlus, UiShieldPlusFilled, UiShieldWarning
+UiShieldWarningFilled, UiShipWheel, UiSidebar, UiSidebarFilled, UiSigma, UiSignIn
+UiSignInFilled, UiSignOut, UiSignOutFilled, UiSiren, UiSirenFilled, UiSkipForward
+UiSkipForwardFilled, UiSkull, UiSkullFilled, UiSliders, UiSlidersFilled, UiSparkles
+UiSparklesFilled, UiSpeaker, UiSpeakerFilled, UiSqlArray, UiSqlColumn, UiSqlConstraint
+UiSqlDatabase, UiSqlForeignKey, UiSqlFunction, UiSqlIndex, UiSqlPrimaryKey, UiSqlQuery
+UiSqlSchema, UiSqlSequence, UiSqlStoredProc, UiSqlTable, UiSqlTableFilled, UiSqlTrigger
+UiSqlView, UiSquare, UiSquareFilled, UiStackFrameDot, UiStar, UiStarFilled
+UiStop, UiString, UiStruct, UiSun, UiSunFilled, UiSwap
+UiSync, UiTable, UiTableFilled, UiTableProperties, UiTablePropertiesFilled, UiTag
 UiTagFilled, UiTerminal, UiTerminalFilled, UiTest, UiThumbsDown, UiThumbsDownFilled
 UiThumbsUp, UiThumbsUpFilled, UiToggleOff, UiToggleOffFilled, UiToggleOn, UiToggleOnFilled
 UiTrait, UiTrash, UiTrashFilled, UiTrendDown, UiTrendDownFilled, UiTrendUp

--- a/make.sh
+++ b/make.sh
@@ -123,6 +123,20 @@ DTS
 # Add ./icon export to package.json
 cat <<< $(jq '.exports["./icon"] = { "types": "./icon/index.d.ts", "require": "./icon/index.js", "import": "./icon/index.mjs", "default": "./icon/index.mjs" }' $reactIconsAll/package.json) > $reactIconsAll/package.json
 
+# Build and copy the generated UI icon package into the main package so
+# consumers can import it as @flanksource/icons/ui.
+icons_ui_dir=$base/packages/ui
+icons_ui_alias=""
+if [ -d "$icons_ui_dir" ]; then
+  echo "Building @flanksource/icons/ui…"
+  (cd "$icons_ui_dir" && pnpm install --silent && pnpm run build >/dev/null)
+  rm -rf $reactIconsAll/ui
+  mkdir -p $reactIconsAll/ui
+  cp -R $icons_ui_dir/dist/. $reactIconsAll/ui/
+  cat <<< $(jq '.exports["./ui"] = { "types": "./ui/index.d.ts", "require": "./ui/index.js", "import": "./ui/index.mjs", "default": "./ui/index.mjs" }' $reactIconsAll/package.json) > $reactIconsAll/package.json
+  icons_ui_alias="--alias:@flanksource/icons/ui=$icons_ui_dir/src/index.ts"
+fi
+
 # Bundle demo app (React + all icons inlined, self-contained for GH Pages).
 # Force every import of `react` and `react/jsx-runtime` to the same physical
 # path so the bundle has a single React instance — otherwise nested deps
@@ -130,15 +144,6 @@ cat <<< $(jq '.exports["./icon"] = { "types": "./icon/index.d.ts", "require": ".
 # "Cannot read properties of null".
 react_root=$(node -e 'console.log(require.resolve("react/package.json"))' | xargs dirname)
 cp DemoApp.tsx $reactIconsAll/
-# Build the new @flanksource/icons-ui package first so the demo can browse it
-# via a side-by-side tab. Skipped silently if the package directory is absent.
-icons_ui_dir=$base/packages/ui
-icons_ui_alias=""
-if [ -d "$icons_ui_dir" ]; then
-  echo "Building @flanksource/icons-ui for the demo…"
-  (cd "$icons_ui_dir" && pnpm install --silent && pnpm run build:codegen >/dev/null)
-  icons_ui_alias="--alias:@flanksource/icons-ui=$icons_ui_dir/src/index.ts"
-fi
 node scripts/generate-llm-txt.mjs
 pnpm exec esbuild $reactIconsAll/DemoApp.tsx \
   --bundle --format=esm --jsx=automatic \

--- a/packages/ui/NOTICE.md
+++ b/packages/ui/NOTICE.md
@@ -1,4 +1,4 @@
-# NOTICE — @flanksource/icons-ui
+# NOTICE — @flanksource/icons/ui
 
 Icons in this package are derived from third-party open-source icon sets.
 The package itself is licensed Apache 2.0; each icon carries the license
@@ -54,6 +54,18 @@ of its upstream source.
 | UiMoonFilled | ph:moon-fill |
 | UiSun | ph:sun-light |
 | UiSunFilled | ph:sun-fill |
+| UiDebugSmall | codicon:debug-alt-small |
+| UiRestart | codicon:debug-restart |
+| UiStackFrameDot | codicon:debug-stackframe-dot |
+| UiDebugStepOver | codicon:debug-step-over |
+| UiPlayCircle | ph:play-circle-light |
+| UiPlayCircleFilled | ph:play-circle-fill |
+| UiResizeVertical | ph:arrows-in-line-vertical-light |
+| UiResizeVerticalFilled | ph:arrows-in-line-vertical-fill |
+| UiListDashes | ph:list-dashes-light |
+| UiListDashesFilled | ph:list-dashes-fill |
+| UiActivity | lucide:activity |
+| UiSync | codicon:sync |
 | UiArrowDownRight | lucide:arrow-down-right |
 | UiArrowUpRight | lucide:arrow-up-right |
 | UiCalculator | lucide:calculator |

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -1,12 +1,12 @@
-# @flanksource/icons-ui
+# @flanksource/icons/ui
 
 Curated UI icon set for Flanksource projects. Each icon is shipped as a tiny
 React component with a stable name across the Flanksource UI surfaces
 (`flanksource-ui`, `clicky-ui`, `facet`, `gavel`, scraper UI, `arch-unit`,
-`oipa-cli`).
+internal CLI tooling).
 
 ```tsx
-import { UiUpload, UiCheck, UiCheckFilled, UiSearch } from "@flanksource/icons-ui";
+import { UiUpload, UiCheck, UiCheckFilled, UiSearch } from "@flanksource/icons/ui";
 
 <UiUpload />                    // outline variant (1em, currentColor)
 <UiCheck size={20} />           // override size

--- a/packages/ui/scripts/build.ts
+++ b/packages/ui/scripts/build.ts
@@ -1,5 +1,5 @@
 /**
- * Codegen for @flanksource/icons-ui.
+ * Codegen for @flanksource/icons/ui.
  *
  * Reads hack/icon-selections.json from the repo root, resolves each pick
  * (Phosphor / JetBrains expui / Iconify alternate / local incumbent SVG),
@@ -679,7 +679,7 @@ async function main() {
         if (defaultColor) {
           parts.push(
             `// source: ${v.spec} (default color: ${defaultColor})`,
-            `export const ${compName}: React.FC<IconProps> & { __source: string; __viewBox: string; __defaultColor: string } = Object.assign(`,
+            `export const ${compName}: React.FC<IconProps> & { __source: string; __viewBox: string; __group: string; __consumerName: string; __defaultColor: string } = Object.assign(`,
             `  ({ size = "1em", className, title, style, ...props }: IconProps) => {`,
             `    const hasOverride = (typeof className === "string" && /\\btext-/.test(className)) || (style && (style as React.CSSProperties).color != null);`,
             `    const finalStyle: React.CSSProperties | undefined = hasOverride ? style : { color: ${JSON.stringify(defaultColor)}, ...(style as React.CSSProperties) };`,
@@ -689,20 +689,20 @@ async function main() {
             `      </svg>`,
             `    );`,
             `  },`,
-            `  { __source: ${JSON.stringify(v.spec)}, __viewBox: ${JSON.stringify(viewBox)}, __defaultColor: ${JSON.stringify(defaultColor)}, displayName: ${JSON.stringify(compName)} },`,
+            `  { __source: ${JSON.stringify(v.spec)}, __viewBox: ${JSON.stringify(viewBox)}, __group: ${JSON.stringify(row.group)}, __consumerName: ${JSON.stringify(cleanConsumer)}, __defaultColor: ${JSON.stringify(defaultColor)}, displayName: ${JSON.stringify(compName)} },`,
             `);`,
             "",
           );
         } else {
           parts.push(
             `// source: ${v.spec}`,
-            `export const ${compName}: React.FC<IconProps> & { __source: string; __viewBox: string } = Object.assign(`,
+            `export const ${compName}: React.FC<IconProps> & { __source: string; __viewBox: string; __group: string; __consumerName: string } = Object.assign(`,
             `  ({ size = "1em", className, title, ...props }: IconProps) => (`,
             `    <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="${viewBox}" role={title ? "img" : "presentation"} aria-label={title} aria-hidden={title ? undefined : true} className={className} {...props}>`,
             `      ${inner}`,
             `    </svg>`,
             `  ),`,
-            `  { __source: ${JSON.stringify(v.spec)}, __viewBox: ${JSON.stringify(viewBox)}, displayName: ${JSON.stringify(compName)} },`,
+            `  { __source: ${JSON.stringify(v.spec)}, __viewBox: ${JSON.stringify(viewBox)}, __group: ${JSON.stringify(row.group)}, __consumerName: ${JSON.stringify(cleanConsumer)}, displayName: ${JSON.stringify(compName)} },`,
             `);`,
             "",
           );
@@ -743,13 +743,13 @@ async function main() {
           const composedInner = composeWithSubIcon(base.inner, base.viewBox, recipe, { tintBase });
           parts.push(
             `// composed: ${base.spec} + ${recipe.marker} (${recipe.position}, ${recipe.color})`,
-            `export const ${subCompName}: React.FC<IconProps> & { __source: string; __viewBox: string } = Object.assign(`,
+            `export const ${subCompName}: React.FC<IconProps> & { __source: string; __viewBox: string; __group: string; __consumerName: string } = Object.assign(`,
             `  ({ size = "1em", className, title, ...props }: IconProps) => (`,
             `    <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="${base.viewBox}" role={title ? "img" : "presentation"} aria-label={title} aria-hidden={title ? undefined : true} className={className} {...props}>`,
             `      ${composedInner}`,
             `    </svg>`,
             `  ),`,
-            `  { __source: ${JSON.stringify(base.spec + " + " + recipe.marker + " marker")}, __viewBox: ${JSON.stringify(base.viewBox)}, displayName: ${JSON.stringify(subCompName)} },`,
+            `  { __source: ${JSON.stringify(base.spec + " + " + recipe.marker + " marker")}, __viewBox: ${JSON.stringify(base.viewBox)}, __group: ${JSON.stringify(row.group)}, __consumerName: ${JSON.stringify(cleanConsumer)}, displayName: ${JSON.stringify(subCompName)} },`,
             `);`,
             "",
           );
@@ -781,8 +781,9 @@ export type IconProps = Omit<SVGProps<SVGSVGElement>, "color"> & {
  * demo / comparison page can show attribution. \`__source\` is the original
  * spec ("ph:upload-simple-light", "jb-expui-nodes:class", "incumbent", …);
  * \`__viewBox\` is the original viewBox preserved from the source SVG.
+ * \`__group\` is the category from hack/icon-selections.json.
  */
-export type IconComponent = FC<IconProps> & { __source: string; __viewBox: string };
+export type IconComponent = FC<IconProps> & { __source: string; __viewBox: string; __group: string; __consumerName: string };
 `,
   );
 
@@ -860,7 +861,7 @@ export function getChangeIcon(
 
   // NOTICE.md — per-icon attribution, generated from selections.
   const noticeLines: string[] = [
-    "# NOTICE — @flanksource/icons-ui",
+    "# NOTICE — @flanksource/icons/ui",
     "",
     "Icons in this package are derived from third-party open-source icon sets.",
     "The package itself is licensed Apache 2.0; each icon carries the license",

--- a/scripts/generate-llm-txt.mjs
+++ b/scripts/generate-llm-txt.mjs
@@ -43,12 +43,12 @@ Use exact icon names from the listings below when generating code.
 
 Demo: https://flanksource.github.io/flanksource-icons/
 Repository: https://github.com/flanksource/flanksource-icons
-NPM packages: @flanksource/icons, @flanksource/icons-ui
+NPM package: @flanksource/icons
 
 ## Install
 
 \`\`\`sh
-pnpm add @flanksource/icons @flanksource/icons-ui
+pnpm add @flanksource/icons
 \`\`\`
 
 Both packages require React as a peer dependency.
@@ -58,7 +58,7 @@ Both packages require React as a peer dependency.
 - Use @flanksource/icons/icon Icon when you know a curated SVG icon name.
 - Use ResourceIcon when the icon name comes from runtime data such as resource type, cloud provider, service, or config class.
 - Use FileTypeIcon when rendering file names or file extensions.
-- Use @flanksource/icons-ui components for UI actions, status, navigation, and product interface symbols.
+- Use @flanksource/icons/ui components for UI actions, status, navigation, and product interface symbols.
 
 ## Usage Examples
 
@@ -79,7 +79,7 @@ export function Examples() {
 \`\`\`
 
 \`\`\`tsx
-import { UiCheck, UiUpload, UiSearch, UiWarningCircleFilled } from "@flanksource/icons-ui";
+import { UiCheck, UiUpload, UiSearch, UiWarningCircleFilled } from "@flanksource/icons/ui";
 
 export function Toolbar() {
   return (
@@ -98,13 +98,13 @@ export function Toolbar() {
 Icon accepts exact names from the @flanksource/icons listing and also supports the aliases and prefix matching built into the package.
 ResourceIcon first checks bundled icons, then falls back to allowed Iconify logo/devicon matches when enabled.
 FileTypeIcon maps common filenames and extensions to bundled icons.
-Most @flanksource/icons-ui outline icons use currentColor, so CSS color utilities such as className="text-blue-500" work.
+Most @flanksource/icons/ui outline icons use currentColor, so CSS color utilities such as className="text-blue-500" work.
 
 ## @flanksource/icons Names (${iconNames.length})
 
 ${wrapList(iconNames)}
 
-## @flanksource/icons-ui Components (${iconsUiNames.length})
+## @flanksource/icons/ui Components (${iconsUiNames.length})
 
 ${wrapList(iconsUiNames, 6)}
 `;


### PR DESCRIPTION
**What**
- Reorganize icons-ui package as subpath export under @flanksource/icons/ui
- Add category metadata to UI icon components via __group and __consumerName properties
- Implement category-based filtering in icon browser with humanized names
- Add "More in [category]" related icons section and category badges to detail view
- Add 12 new UI control icons (debug-small, restart, stack-frame-dot, debug-step-over, play-circle, resize-vertical, list-dashes, activity, sync)

**Why**
- Consolidate icon packages under single @flanksource/icons namespace
- Improve icon discoverability through category filtering
- Enhance icon browser UX with related icons and metadata

**Notes**
- Build process updated to copy ui package into main icons package exports
- Documentation and examples updated for new import path
- Version bumped to 1.0.59