### PR TITLE
fix(security): resolve code scanning alerts (stack trace exposure, workflow permissions)

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -5,9 +5,14 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository

--- a/hack/serve-comparison.ts
+++ b/hack/serve-comparison.ts
@@ -31,8 +31,11 @@ const server = createServer(async (req, res) => {
       res.end(JSON.stringify({ ok: true, path: selectionsPath }));
       console.log(`[save] ${parsed.chosen ?? "?"} / ${parsed.total ?? "?"} → ${selectionsPath}`);
     } catch (err) {
+      // Log the real error server-side; return a generic message so we don't
+      // leak internal details (stack traces, paths) to the client.
+      console.error("[save] failed to persist selections:", err);
       res.writeHead(400, { "content-type": "application/json" });
-      res.end(JSON.stringify({ ok: false, error: String(err) }));
+      res.end(JSON.stringify({ ok: false, error: "invalid request" }));
     }
     return;
   }


### PR DESCRIPTION
## Summary

Resolves the two open CodeQL code scanning alerts on `main`:

1. **Information exposure through a stack trace** (`hack/serve-comparison.ts:35`, Medium)
2. **Workflow does not contain permissions** (`.github/workflows/gh-pages.yaml:10`, Medium)

## Changes

### `hack/serve-comparison.ts`
The `/__save_selections` error handler previously returned `String(err)` in the JSON response, exposing internal error details (stack traces, file paths) to the client. Now the real error is logged server-side via `console.error`, and the client receives a generic `"invalid request"` message.

### `.github/workflows/gh-pages.yaml`
Added an explicit least-privilege `permissions` block:
- `contents: read` at the workflow level (default for all jobs)
- `contents: write` scoped to the `build` job, which is the only permission the `peaceiris/actions-gh-pages` deploy step needs to push to the `gh-pages` branch.

## Testing
- No behavioral change to successful requests.
- Error responses now omit internal details while still returning HTTP 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016p8hzUdLNJHkaeRD8YjT1i)_